### PR TITLE
Move react and react-native to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "react-native-svg-mock": "^1.0.2"
   },
   "peerDependencies": {
+    "react": "^15.3.2",
+    "react-native": "~0.37.0",
     "react-native-svg": "^4.3.1"
   },
   "dependencies": {
-    "react": "^15.3.2",
-    "react-native": "~0.37.0",
     "victory-chart-native": "^1.3.0",
     "victory-core": "^9.0.2",
     "victory-core-native": "^3.0.0",


### PR DESCRIPTION
To my understanding, React and React-Native should be peer dependencies of Victory-Native and not regular dependencies, as Victory-Native expects to be run alongside them in a project where they are already installed.

This also has real-life consequences: before this fix, if you created a new React Native project and then installed Victory Native, the project would fail to build, as Victory Native would install its own copy of React Native leading to duplicates (which the React Native packager doesn't like).