### PR TITLE
Enable android chart animations

### DIFF
--- a/lib/components/victory-area.js
+++ b/lib/components/victory-area.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { VictoryArea } from "victory-chart/src";
 
 import VictoryLabel from "./victory-label";
@@ -15,9 +15,5 @@ export default class extends VictoryArea {
     containerComponent: <VictoryContainer/>,
     groupComponent: <VictoryClipContainer/>,
     width: Dimensions.get("window").width
-  }
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
   }
 }

--- a/lib/components/victory-axis.js
+++ b/lib/components/victory-axis.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryAxis } from "victory-chart/src";
 
@@ -19,8 +19,4 @@ export default class extends VictoryAxis {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
 }

--- a/lib/components/victory-bar.js
+++ b/lib/components/victory-bar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 
 import VictoryLabel from "./victory-label";
@@ -16,9 +16,5 @@ export default class extends VictoryBar {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  }
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
   }
 }

--- a/lib/components/victory-candlestick.js
+++ b/lib/components/victory-candlestick.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 
 import VictoryLabel from "./victory-label";
@@ -16,9 +16,5 @@ export default class extends VictoryCandlestick {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  }
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
   }
 }

--- a/lib/components/victory-errorbar.js
+++ b/lib/components/victory-errorbar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryErrorBar } from "victory-chart/src";
 
@@ -14,9 +14,4 @@ export default class extends VictoryErrorBar {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
-
 }

--- a/lib/components/victory-line.js
+++ b/lib/components/victory-line.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { VictoryLine } from "victory-chart/src";
 
 import VictoryLabel from "./victory-label";
@@ -16,9 +16,4 @@ export default class extends VictoryLine {
     groupComponent: <VictoryClipContainer/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
-
 }

--- a/lib/components/victory-pie.js
+++ b/lib/components/victory-pie.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { Platform } from "react-native";
 import { VictoryPie } from "victory-pie/src";
 
 import VictoryLabel from "./victory-label";
@@ -20,9 +19,5 @@ export default class extends VictoryPie {
   renderGroup(props, children) {
     const { x, y } = this.getOffset(props);
     return React.cloneElement(props.groupComponent, { translateX: x, translateY: y }, children);
-  }
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
   }
 }

--- a/lib/components/victory-scatter.js
+++ b/lib/components/victory-scatter.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryScatter } from "victory-chart/src";
 
@@ -16,8 +16,4 @@ export default class extends VictoryScatter {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
 }

--- a/lib/components/victory-voronoi-tooltip.js
+++ b/lib/components/victory-voronoi-tooltip.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryVoronoiTooltip } from "victory-chart/src";
 
@@ -16,9 +16,4 @@ export default class extends VictoryVoronoiTooltip {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
-
 }

--- a/lib/components/victory-voronoi.js
+++ b/lib/components/victory-voronoi.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryVoronoi } from "victory-chart/src";
 
@@ -16,8 +16,4 @@ export default class extends VictoryVoronoi {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  shouldAnimate() {
-    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
-  }
 }


### PR DESCRIPTION
As far as I can tell from my preliminary testing, animations are working on android. This PR would stop victory-native from disabling them.