### PR TITLE
Fix transitions and clipping

### DIFF
--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -23,11 +23,7 @@ export default class extends VictoryClipContainer {
 
   // Overrides method in victory-core
   renderClipComponent(props, clipId) {
-    // eslint-disable-next-line prefer-const
-    let { clipPadding, translateX, translateY, clipHeight, clipWidth, width, height } = props;
-    // ensure clipWidth/clipHeight are non-zero, as react-native-svg Clip Rect cannot accept them
-    clipWidth = clipWidth || width;
-    clipHeight = clipHeight || height;
+    const { clipPadding, translateX, translateY, clipHeight, clipWidth } = props;
     return (
       <ClipPath
         clipPadding={clipPadding}

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -8,7 +8,7 @@ export default class extends ClipPath {
     return (
       <Defs>
         <Clip id={`${id}`}>
-          <Rect {...props} clipWidth={props.clipWidth || 1} clipHeight={props.clipHeight || 1}/>
+          <Rect {...props}/>
         </Clip>
       </Defs>
     );

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "test": "mocha --compilers test/compiler.js --recursive test/spec/*.js"
   },
   "devDependencies": {
+    "@jonny/react-native-mock": "^0.4.0",
     "babel-core": "^6.13.2",
     "babel-eslint": "^6.1.2",
     "babel-plugin-module-resolver": "^2.5.0",
     "babel-preset-react-native": "^1.9.0",
     "babel-register": "^6.11.6",
     "chai": "^3.5.0",
-    "enzyme": "^2.4.1",
+    "enzyme": "^2.8.2",
     "eslint": "^2.0.0",
     "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-filenames": "^1.2.0",
@@ -39,11 +40,12 @@
     "mocha": "^3.0.2",
     "react": "^16.0.0-alpha.12",
     "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4",
+    "react-dom": "^16.0.0-alpha.12",
     "react-native": "^0.45.0",
-    "react-native-mock": "^0.2.5",
+    "react-native-mock": "^0.3.1",
     "react-native-svg": "^5.2.0",
-    "react-native-svg-mock": "^1.0.2"
+    "react-native-svg-mock": "^1.0.2",
+    "react-test-renderer": "^16.0.0-alpha.12"
   },
   "peerDependencies": {
     "react": "^16.0.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -37,18 +37,18 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.3",
     "mocha": "^3.0.2",
-    "react": "^15.5.4",
+    "react": "^16.0.0-alpha.12",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
-    "react-native": "~0.42.0",
+    "react-native": "^0.45.0",
     "react-native-mock": "^0.2.5",
-    "react-native-svg": "^5.1.5",
+    "react-native-svg": "^5.2.0",
     "react-native-svg-mock": "^1.0.2"
   },
   "peerDependencies": {
-    "react": "^15.5.4 || >=16.0.0-alpha.6",
-    "react-native": ">=0.42.0",
-    "react-native-svg": "^5.1.8"
+    "react": "^16.0.0-alpha.12",
+    "react-native": "^0.45.0",
+    "react-native-svg": "^5.2.0"
   },
   "dependencies": {
     "lodash": "^4.17.4",

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -4,7 +4,7 @@ var babel = require("babel-core");
 var origJs = require.extensions[".js"];
 
 // Mock react-native and react-native-svg
-require("react-native-mock/mock");
+require("@jonny/react-native-mock/mock");
 require("react-native-svg-mock/mock");
 
 // Compile a path with babel


### PR DESCRIPTION
#77 Entrance transitions were completely broken, as was all dynamic clipping. Upgrading to `react-native-svg@5.2.0` fixed this; however, that upgrade necessitated upgrades to `react-native@0.45.0` and `react@16.0.0-alpha.12`.

Also cleaned up a related hack (from #74) that is not needed anymore, and some bogus props that made debugging more confusing :P 