### PR TITLE
Update victory

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -29,6 +29,7 @@ import {
   VictoryBrushContainer,
   VictoryCursorContainer,
   VictoryPie,
+  VictoryLabel,
   createContainer
 } from "victory-native";
 
@@ -138,13 +139,6 @@ export default class Demo extends Component {
         <Text style={styles.text}>{"Native"}</Text>
         <Text style={styles.text}>{"Demo\n"}</Text>
 
-        <VictoryPolarAxis
-          theme={VictoryTheme.material}
-          startAngle={0} endAngle={180}
-          labelPlacement="perpendicular"
-          tickValues={["Cat", "Dog", "Bird", "Snake"]}
-        />
-
         <VictoryChart polar theme={VictoryTheme.material}>
           <VictoryBar
             style={{ data: { fill: "tomato", opacity: 0.5 } }}
@@ -180,7 +174,8 @@ export default class Demo extends Component {
             />
           }
         >
-         <VictoryBar/>
+          <VictoryAxis tickLabelComponent={<VictoryLabel angle={45}/>}/>
+          <VictoryBar/>
         </VictoryChart>
 
         <Text style={styles.text}>{"VictoryBrushContainer"}</Text>
@@ -193,7 +188,7 @@ export default class Demo extends Component {
             />
           }
         >
-         <VictoryBar/>
+          <VictoryBar/>
         </VictoryChart>
 
         <Text style={styles.text}>{"VictorySelectionContainer"}</Text>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -12,6 +12,7 @@ import {
 import Svg from "react-native-svg";
 import {
   VictoryAxis,
+  VictoryPolarAxis,
   VictoryChart,
   VictoryGroup,
   VictoryStack,
@@ -30,6 +31,8 @@ import {
   VictoryPie,
   createContainer
 } from "victory-native";
+
+import { VictoryTheme } from "victory-core";
 
 const styles = StyleSheet.create({
   container: {
@@ -134,6 +137,38 @@ export default class Demo extends Component {
         <Text style={styles.text}>{"Victory"}</Text>
         <Text style={styles.text}>{"Native"}</Text>
         <Text style={styles.text}>{"Demo\n"}</Text>
+
+        <VictoryPolarAxis
+          theme={VictoryTheme.material}
+          startAngle={0} endAngle={180}
+          labelPlacement="perpendicular"
+          tickValues={["Cat", "Dog", "Bird", "Snake"]}
+        />
+
+        <VictoryChart polar theme={VictoryTheme.material}>
+          <VictoryBar
+            style={{ data: { fill: "tomato", opacity: 0.5 } }}
+            data={[
+              { x: 15, y: 20, label: 1, fill: "red" },
+              { x: 25, y: 30, label: 2, fill: "orange" },
+              { x: 35, y: 65, label: 3, fill: "gold" },
+              { x: 40, y: 50, label: 4, fill: "blue" },
+              { x: 45, y: 40, label: 5, fill: "cyan" },
+              { x: 50, y: 30, label: 6, fill: "green" }
+            ]}
+          />
+          <VictoryScatter
+            style={{ data: { fill: "black" } }}
+            data={[
+              { x: 15, y: 20 },
+              { x: 25, y: 30 },
+              { x: 35, y: 65 },
+              { x: 40, y: 50 },
+              { x: 45, y: 40 },
+              { x: 50, y: 30 }
+            ]}
+          />
+        </VictoryChart>
 
         <Text style={styles.text}>{"VictoryCursorContainer"}</Text>
         <VictoryChart

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -12,7 +12,6 @@ import {
 import Svg from "react-native-svg";
 import {
   VictoryAxis,
-  VictoryPolarAxis,
   VictoryChart,
   VictoryGroup,
   VictoryStack,

--- a/lib/components/victory-chart.js
+++ b/lib/components/victory-chart.js
@@ -4,6 +4,7 @@ import { G } from "react-native-svg";
 import { VictoryChart } from "victory-chart/src";
 
 import VictoryAxis from "./victory-axis";
+import VictoryPolarAxis from "./victory-polar-axis";
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryChart {
@@ -14,6 +15,10 @@ export default class extends VictoryChart {
     defaultAxes: {
       independent: <VictoryAxis/>,
       dependent: <VictoryAxis dependentAxis/>
+    },
+    defaultPolarAxes: {
+      independent: <VictoryPolarAxis/>,
+      dependent: <VictoryPolarAxis dependentAxis/>
     },
     width: Dimensions.get("window").width
   };

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -13,8 +13,9 @@ export default class extends VictoryLabel {
 
   // Overrides method in victory-core
   renderElements(props) {
-    const { x, y, dx, className, events } = props;
-    const transform = NativeHelpers.getTransform(this.transform);
+    const { x, y, dx, className, events, angle } = props;
+    // const transform = NativeHelpers.getTransform(this.transform);
+    const transform = { rotate: angle };
     return (
       <G {...transform} {...events} className={className}>
         {this.content.map((line, i) => {

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,9 +1,8 @@
 import React from "react";
-import { Text, G, TSpan } from "react-native-svg";
+import { Text, TSpan } from "react-native-svg";
 import { VictoryLabel } from "victory-core/src";
 
 import { NativeHelpers } from "../index";
-import { Helpers } from "victory-core";
 
 export default class extends VictoryLabel {
   static defaultProps = {
@@ -14,7 +13,7 @@ export default class extends VictoryLabel {
 
   // Overrides method in victory-core
   renderElements(props) {
-    const { x, y, className, events  } = props;
+    const { x, y, className, events } = props;
     const textProps = {
       dx: this.dx, dy: this.dy, x, y, className,
       textAnchor: this.textAnchor

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,8 +1,9 @@
 import React from "react";
-import { Text, G } from "react-native-svg";
+import { Text, G, TSpan } from "react-native-svg";
 import { VictoryLabel } from "victory-core/src";
 
 import { NativeHelpers } from "../index";
+import { Helpers } from "victory-core";
 
 export default class extends VictoryLabel {
   static defaultProps = {
@@ -13,25 +14,30 @@ export default class extends VictoryLabel {
 
   // Overrides method in victory-core
   renderElements(props) {
-    const { x, y, dx, className, events, angle } = props;
-    // const transform = NativeHelpers.getTransform(this.transform);
-    const transform = { rotate: angle };
+    const { x, y, className, events  } = props;
+    const textProps = {
+      dx: this.dx, dy: this.dy, x, y, className,
+      textAnchor: this.textAnchor
+    };
+
+    const transform = NativeHelpers.getTransform(this.transform);
     return (
-      <G {...transform} {...events} className={className}>
+      <Text {...transform} {...textProps}
+        {...events}
+      >
         {this.content.map((line, i) => {
           const style = NativeHelpers.getStyle(this.style[i] || this.style[0]);
           const lastStyle = NativeHelpers.getStyle(this.style[i - 1] || this.style[0]);
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
           const textAnchor = style.textAnchor || this.textAnchor;
-          const lineOffset = i ? fontSize : 0;
-          const dy = this.dy - fontSize + lineOffset;
+          const dy = i ? (this.lineHeight * fontSize) : 0;
           return (
-            <Text {...style} key={i} x={x} y={y} dx={dx} dy={dy} textAnchor={textAnchor}>
+            <TSpan key={i} x={x} y={y} dy={dy} dx={this.dx} {...style} textAnchor={textAnchor}>
               {line}
-            </Text>
+            </TSpan>
           );
         })}
-      </G>
+      </Text>
     );
   }
 }

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { Dimensions } from "react-native";
+import { G } from "react-native-svg";
+import { VictoryPolarAxis } from "victory-chart/src";
+import { Helpers } from "victory-core";
+import VictoryLabel from "./victory-label";
+import VictoryContainer from "./victory-container";
+import { Line, Arc } from "../index";
+
+export default class extends VictoryPolarAxis {
+  static defaultProps = {
+    ...VictoryPolarAxis.defaultProps,
+    axisComponent: <Line/>,
+    axisLabelComponent: <VictoryLabel/>,
+    circularAxisComponent: <Arc type={"axis"}/>,
+    circularGridComponent: <Arc type={"grid"}/>,
+    tickLabelComponent: <VictoryLabel/>,
+    tickComponent: <Line/>,
+    gridComponent: <Line/>,
+    containerComponent: <VictoryContainer/>,
+    groupComponent: <G/>,
+    width: Dimensions.get("window").width
+  };
+
+  // Overridden in victory-native
+  renderGroup(props, children) {
+    const origin = Helpers.getPolarOrigin(props);
+    const transform = { translateX: origin.x, translateY: origin.y };
+    return React.cloneElement(props.groupComponent, transform, children);
+  }
+}

--- a/lib/components/victory-portal/portal.js
+++ b/lib/components/victory-portal/portal.js
@@ -14,7 +14,7 @@ export default class extends Portal {
       {},
       Object.keys(this.map).map((key) => {
         const el = this.map[key];
-        return el ? React.cloneElement(el, {key}) : <G/>;
+        return el ? React.cloneElement(el, { key }) : <G/>;
       })
     );
   }

--- a/lib/components/victory-primitives/arc.js
+++ b/lib/components/victory-primitives/arc.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Path } from "react-native-svg";
+import { NativeHelpers } from "../../index";
+import { Arc } from "victory-core";
+
+export default class extends Arc {
+  // Overridden in victory-core-native
+  renderAxisLine(props, style, events) {
+    const { role, shapeRendering, className } = props;
+    const nativeStyle = NativeHelpers.getStyle(style);
+    const path = this.getArcPath(props);
+    return (
+      <Path className={className}
+        d={path}
+        style={style}
+        role={role || "presentation"}
+        shapeRendering={shapeRendering || "auto"}
+        {...nativeStyle}
+        {...events}
+      />
+    );
+  }
+}

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -18,6 +18,7 @@ export default class extends Area {
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path
+        key={"area"}
         shapeRendering={shapeRendering || "auto"}
         role={role || "presentation"}
         d={path}
@@ -40,6 +41,7 @@ export default class extends Area {
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path
+        key={"area-stroke"}
         shapeRendering={shapeRendering || "auto"}
         role={role || "presentation"}
         d={path}

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -4,50 +4,50 @@ import { NativeHelpers } from "../../index";
 import { Area } from "victory-core";
 
 export default class extends Area {
-  // Overrides method in victory-core
 
   static defaultProps = {
     groupComponent: <G/>
   };
 
-  renderArea(paths, style, events) {
+  // Overrides method in victory-core
+  renderArea(path, style, events) {
     const areaStroke = style.stroke ? "none" : style.fill;
-    const areaStyle = NativeHelpers.getStyle(Object.assign({}, style, {stroke: areaStroke}));
-    const { role, shapeRendering, className } = this.props;
-    return paths.map((path, index) => {
-      return (
-        <Path
-          key={`area-${index}`}
-          shapeRendering={shapeRendering || "auto"}
-          role={role || "presentation"}
-          d={path}
-          className={className}
-          {...areaStyle}
-          {...events}
-        />
-      );
-    });
+    const areaStyle = NativeHelpers.getStyle(Object.assign({}, style, { stroke: areaStroke }));
+    const { role, shapeRendering, className, polar, origin } = this.props;
+    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const transform = NativeHelpers.getTransform(baseTransform);
+    return (
+      <Path
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        d={path}
+        className={className}
+        {...transform}
+        {...areaStyle}
+        {...events}
+      />
+    );
   }
 
   // Overrides method in victory-core
-  renderLine(paths, style, events) {
+  renderLine(path, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
       return [];
     }
-    const { role, shapeRendering, className } = this.props;
-    const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, {fill: "none"}));
-    return paths.map((path, index) => {
-      return (
-        <Path
-          key={`area-stroke-${index}`}
-          shapeRendering={shapeRendering || "auto"}
-          role={role || "presentation"}
-          d={path}
-          className={className}
-          {...lineStyle}
-          {...events}
-        />
-      );
-    });
+    const { role, shapeRendering, className, polar, origin } = this.props;
+    const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, { fill: "none" }));
+    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const transform = NativeHelpers.getTransform(baseTransform);
+    return (
+      <Path
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        d={path}
+        className={className}
+        {...transform}
+        {...lineStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -14,7 +14,7 @@ export default class extends Area {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = NativeHelpers.getStyle(Object.assign({}, style, { stroke: areaStroke }));
     const { role, shapeRendering, className, polar, origin } = this.props;
-    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path
@@ -36,7 +36,7 @@ export default class extends Area {
     }
     const { role, shapeRendering, className, polar, origin } = this.props;
     const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, { fill: "none" }));
-    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -8,7 +8,7 @@ export default class extends Bar {
   renderBar(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className, polar, origin } = this.props;
-    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -4,16 +4,19 @@ import { NativeHelpers } from "../../index";
 import { Bar } from "victory-core";
 
 export default class extends Bar {
-   // Overrides method in victory-core
+  // Overrides method in victory-core
   renderBar(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
-    const { role, shapeRendering, className } = this.props;
+    const { role, shapeRendering, className, polar, origin } = this.props;
+    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path
         className={className}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         d={path}
+        {...transform}
         {...nativeStyle}
         {...events}
       />

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ClipPath as Clip, Rect, Defs } from "react-native-svg";
+import { ClipPath as Clip, Rect, Defs, Circle } from "react-native-svg";
 import { ClipPath } from "victory-core";
 
 export default class extends ClipPath {
@@ -9,6 +9,17 @@ export default class extends ClipPath {
       <Defs>
         <Clip id={`${id}`}>
           <Rect {...props}/>
+        </Clip>
+      </Defs>
+    );
+  }
+
+  // Overrides method in victory-core
+  renderPolarClipPath(props, id) {
+    return (
+      <Defs>
+        <Clip id={id}>
+          <Circle {...props}/>
         </Clip>
       </Defs>
     );

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -9,21 +9,22 @@ export default class extends Curve {
   };
 
   // Overrides method in victory-core
-  renderLine(paths, style, events) {
-    const { role, shapeRendering, className } = this.props;
+  renderLine(path, style, events) {
+    const { role, shapeRendering, className, polar, origin } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    return paths.map((path, index) => {
-      return (
-        <Path
-          key={`area-stroke-${index}`}
-          shapeRendering={shapeRendering || "auto"}
-          role={role || "presentation"}
-          d={path}
-          className={className}
-          {...nativeStyle}
-          {...events}
-        />
-      );
-    });
+    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const transform = NativeHelpers.getTransform(baseTransform);
+    return (
+      <Path
+        key={"curve"}
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        d={path}
+        className={className}
+        {...transform}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -12,7 +12,7 @@ export default class extends Curve {
   renderLine(path, style, events) {
     const { role, shapeRendering, className, polar, origin } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    const baseTransform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
+    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     const transform = NativeHelpers.getTransform(baseTransform);
     return (
       <Path

--- a/lib/helpers/native-helpers.js
+++ b/lib/helpers/native-helpers.js
@@ -14,10 +14,11 @@ export default {
       omit(style, [...unsupportedProps, ...strokeProperties]) : omit(style, unsupportedProps);
   },
 
-  parseTransformString(str) {
-    if (typeof str !== "string") {
+  parseTransformString(baseString) {
+    if (typeof baseString !== "string") {
       return undefined;
     }
+    const str = baseString.replace(",", "");
     const translate = str.match(/translate\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
     const scale = str.match(/scale\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
     const rotate = str.match(/rotate\(\s*([^\s,)]+)/);

--- a/lib/helpers/native-helpers.js
+++ b/lib/helpers/native-helpers.js
@@ -21,13 +21,19 @@ export default {
     const str = baseString.replace(",", "");
     const translate = str.match(/translate\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
     const scale = str.match(/scale\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
-    const rotate = str.match(/rotate\(\s*([^\s,)]+)/);
+    const rotate = str.match(/rotate\(\s*([^\s,)]+)/); // eslint-disable-line no-unused-vars
+
+    // TODO: Currently rotations are causing an unwanted translation.
+    // See https://github.com/react-native-community/react-native-svg/issues/242
+    const rotation = undefined;
+    // const rotation = Array.isArray(rotate) ? rotate[1] : undefined;
+
     return {
       translateX: Array.isArray(translate) ? translate[1] : undefined,
       translateY: Array.isArray(translate) ? translate[2] : undefined,
       scaleX: Array.isArray(scale) ? scale[1] : undefined,
       scaleY: Array.isArray(scale) ? scale[2] : undefined,
-      rotate: Array.isArray(rotate) ? rotate[1] : undefined
+      rotate: rotation
     };
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ export {
   VictoryTransition
 } from "victory-core";
 
+export { default as Arc } from "./components/victory-primitives/arc";
 export { default as Area } from "./components/victory-primitives/area";
 export { default as Bar } from "./components/victory-primitives/bar";
 export { default as Candle } from "./components/victory-primitives/candle";
@@ -23,6 +24,7 @@ export { default as VictoryPortal } from "./components/victory-portal/victory-po
 export { default as Portal } from "./components/victory-portal/portal";
 export { default as VictoryArea } from "./components/victory-area";
 export { default as VictoryAxis } from "./components/victory-axis";
+export { default as VictoryPolarAxis } from "./components/victory-polar-axis";
 export { default as VictoryBar } from "./components/victory-bar";
 export { default as VictoryGroup } from "./components/victory-group";
 export { default as VictoryLine } from "./components/victory-line";

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native": "^0.45.0",
     "react-native-mock": "^0.3.1",
     "react-native-svg": "^5.2.0",
-    "react-native-svg-mock": "^1.0.2",
+    "react-native-svg-mock": "^1.1.0",
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "victory-chart": "^20.0.0",
-    "victory-core": "^15.2.0",
-    "victory-pie": "^10.3.0"
+    "victory-chart": "git://github.com/formidablelabs/victory-chart#support-native-polar",
+    "victory-core": "^16.0.0",
+    "victory-pie": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "victory-chart": "git://github.com/formidablelabs/victory-chart#support-native-polar",
+    "victory-chart": "^21.1.2",
     "victory-core": "^16.0.0",
     "victory-pie": "^11.0.0"
   }

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import {
   VictoryArea,
   VictoryAxis,
+  VictoryPolarAxis,
   VictoryBar,
   VictoryCandlestick,
   VictoryChart,
@@ -23,6 +24,7 @@ import {
 const components = [
   { component: VictoryArea, name: "VictoryArea" },
   { component: VictoryAxis, name: "VictoryAxis" },
+  { component: VictoryPolarAxis, name: "VictoryPolarAxis" },
   { component: VictoryBar, name: "VictoryBar" },
   { component: VictoryCandlestick, name: "VictoryCandlestick" },
   { component: VictoryChart, name: "VictoryChart" },


### PR DESCRIPTION
cc/ @chrisbolin this PR updates Victory to 0.21.0 and adds support for polar charts.

Caveats:
I couldn't figure out how to work around https://github.com/FormidableLabs/victory-native/issues/103, so I've temporarily disabled text rotations

~Spurious test failure for `VictoryLabel`~ Updated `react-native-svg-mock` to include `TSpan` mock
