### PR TITLE
improve Area rendering

### DIFF
--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -33,7 +33,7 @@ export default class extends Area {
   // Overrides method in victory-core
   renderLine(path, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
-      return [];
+      return null;
     }
     const { role, shapeRendering, className, polar, origin } = this.props;
     const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, { fill: "none" }));


### PR DESCRIPTION
return false-y value from renderLine, in accordance with victory-core https://github.com/FormidableLabs/victory-core/pull/259

Note: Nothing is currently broken, but this change allows us to skip some extra work in victory-core's Area render function when `renderLine` returns "nothing" (before it was an empty array, now `null`)