### PR TITLE
Add userSelect as an unsupported style prop

### DIFF
--- a/lib/helpers/native-helpers.js
+++ b/lib/helpers/native-helpers.js
@@ -5,7 +5,7 @@ export default {
   getStyle(style) {
     if (!style) { return undefined; }
     // TODO: more style fixes for Native?
-    const unsupportedProps = ["pointerEvents", "x", "y", "_x", "_y"];
+    const unsupportedProps = ["pointerEvents", "x", "y", "_x", "_y", "userSelect"];
     const strokeProperties = [
       "stroke", "strokeWidth", "strokeOpacity", "strokeDasharray",
       "strokeDashoffset", "strokeLinecap", "strokeLinejoin"


### PR DESCRIPTION
In react-native 0.50.3, this style prop causes a warning when it is passed down to VictoryContainer.