### PR TITLE
remove transform parsing

### DIFF
--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -7,12 +7,11 @@ export default class extends VictoryClipContainer {
 
   // Overrides method in victory-core
   renderClippedGroup(props, clipId) {
-    const { style, events, children, className } = props;
+    const { style, events, children, className, transform } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    const transform = NativeHelpers.getTransform(props.transform);
     const clipComponent = this.renderClipComponent(props, clipId);
     return (
-      <G {...nativeStyle} {...events} {...transform} className={className}>
+      <G {...nativeStyle} {...events} transform={transform} className={className}>
         {clipComponent}
         <G clipPath={`url(#${clipId})`}>
           {children}
@@ -38,11 +37,10 @@ export default class extends VictoryClipContainer {
 
   // Overrides method in victory-core
   renderGroup(props) {
-    const { style, events, children, className } = props;
+    const { style, events, children, className, transform } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    const transform = NativeHelpers.getTransform(props.transform);
     return (
-      <G {...nativeStyle} {...events} {...transform} className={className}>
+      <G {...nativeStyle} {...events} transform={transform} className={className}>
         {children}
       </G>
     );

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text, TSpan } from "react-native-svg";
-import { VictoryLabel, LabelHelpers } from "victory-core/src";
+import { VictoryLabel } from "victory-core/src";
 
 import { NativeHelpers } from "../index";
 
@@ -10,23 +10,6 @@ export default class extends VictoryLabel {
     capHeight: 0.71,
     lineHeight: 1
   };
-
-  // temporarily override methd in victory-core. Remove once once issue in rnsvg is fixed
-  // https://github.com/react-native-community/react-native-svg/issues/242
-  // Note: this change will temporarily ignore all transformations other than rotations.
-  getTransform(props, style) {
-    const { x, y, polar } = props;
-    const defaultAngle = polar ? LabelHelpers.getPolarAngle(props) : 0;
-    const angle = style.angle || props.angle || defaultAngle;
-    const r = angle ? angle * (Math.PI / 180) : 0;
-    const a = Math.cos(r);
-    const b = Math.sin(r);
-    const c = -1 * Math.sin(r);
-    const d = Math.cos(r);
-    const e = (-1 * x * Math.cos(r)) + (y * Math.sin(r)) + x;
-    const f = (-1 * x * Math.sin(r)) - (y * Math.cos(r)) + y;
-    return `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;
-  }
 
   // Overrides method in victory-core
   renderElements(props) {

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryPolarAxis } from "victory-chart/src";
-import { Helpers } from "victory-core";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import { Line, Arc } from "../index";
@@ -21,11 +20,4 @@ export default class extends VictoryPolarAxis {
     groupComponent: <G/>,
     width: Dimensions.get("window").width
   };
-
-  // Overridden in victory-native
-  renderGroup(props, children) {
-    const origin = Helpers.getPolarOrigin(props);
-    const transform = { translateX: origin.x, translateY: origin.y };
-    return React.cloneElement(props.groupComponent, transform, children);
-  }
 }

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -14,8 +14,7 @@ export default class extends Area {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = NativeHelpers.getStyle(Object.assign({}, style, { stroke: areaStroke }));
     const { role, shapeRendering, className, polar, origin } = this.props;
-    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    const transform = NativeHelpers.getTransform(baseTransform);
+    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     return (
       <Path
         key={"area"}
@@ -23,7 +22,7 @@ export default class extends Area {
         role={role || "presentation"}
         d={path}
         className={className}
-        {...transform}
+        transform={transform}
         {...areaStyle}
         {...events}
       />
@@ -37,8 +36,7 @@ export default class extends Area {
     }
     const { role, shapeRendering, className, polar, origin } = this.props;
     const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, { fill: "none" }));
-    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    const transform = NativeHelpers.getTransform(baseTransform);
+    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     return (
       <Path
         key={"area-stroke"}
@@ -46,7 +44,7 @@ export default class extends Area {
         role={role || "presentation"}
         d={path}
         className={className}
-        {...transform}
+        transform={transform}
         {...lineStyle}
         {...events}
       />

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -8,15 +8,14 @@ export default class extends Bar {
   renderBar(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className, polar, origin } = this.props;
-    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    const transform = NativeHelpers.getTransform(baseTransform);
+    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     return (
       <Path
         className={className}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         d={path}
-        {...transform}
+        transform={transform}
         {...nativeStyle}
         {...events}
       />

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -12,8 +12,7 @@ export default class extends Curve {
   renderLine(path, style, events) {
     const { role, shapeRendering, className, polar, origin } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    const baseTransform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    const transform = NativeHelpers.getTransform(baseTransform);
+    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
     return (
       <Path
         key={"curve"}
@@ -21,7 +20,7 @@ export default class extends Curve {
         role={role || "presentation"}
         d={path}
         className={className}
-        {...transform}
+        transform={transform}
         {...nativeStyle}
         {...events}
       />

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -8,15 +8,14 @@ export default class extends Slice {
   renderSlice(path, style, events) {
     const { role, shapeRendering, className, origin } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);
-    const baseTransform = origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    const transform = NativeHelpers.getTransform(baseTransform);
+    const transform = origin ? `translate(${origin.x} ${origin.y})` : undefined;
     return (
       <Path
         className={className}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         d={path}
-        {...transform}
+        transform={transform}
         {...nativeStyle}
         {...events}
       />

--- a/lib/helpers/native-helpers.js
+++ b/lib/helpers/native-helpers.js
@@ -12,33 +12,5 @@ export default {
     ];
     return style.stroke === "none" || style.stroke === "transparent" ?
       omit(style, [...unsupportedProps, ...strokeProperties]) : omit(style, unsupportedProps);
-  },
-
-  parseTransformString(baseString) {
-    if (typeof baseString !== "string") {
-      return undefined;
-    }
-    const str = baseString.replace(",", "");
-    const translate = str.match(/translate\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
-    const scale = str.match(/scale\(\s*([^\s,)]+)[ ,]([^\s,)]+)/);
-    const rotate = str.match(/rotate\(\s*([^\s,)]+)/); // eslint-disable-line no-unused-vars
-
-    // TODO: Currently rotations are causing an unwanted translation.
-    // See https://github.com/react-native-community/react-native-svg/issues/242
-    const rotation = undefined;
-    // const rotation = Array.isArray(rotate) ? rotate[1] : undefined;
-
-    return {
-      translateX: Array.isArray(translate) ? translate[1] : undefined,
-      translateY: Array.isArray(translate) ? translate[2] : undefined,
-      scaleX: Array.isArray(scale) ? scale[1] : undefined,
-      scaleY: Array.isArray(scale) ? scale[2] : undefined,
-      rotate: rotation
-    };
-  },
-
-  getTransform(baseTransform) {
-    return typeof baseTransform !== "string" ?
-      baseTransform : this.parseTransformString(baseTransform);
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "victory-native",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -52,7 +52,7 @@
       "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.11",
+        "mime-types": "2.1.17",
         "negotiator": "0.5.3"
       }
     },
@@ -353,6 +353,17 @@
         "trim-right": "1.0.1"
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helper-builder-react-jsx": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
@@ -386,6 +397,17 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -542,6 +564,12 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
     "babel-plugin-syntax-flow": {
@@ -788,6 +816,17 @@
       "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
       "dev": true,
       "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
         "babel-runtime": "6.26.0"
       }
     },
@@ -1101,9 +1140,9 @@
       "dev": true
     },
     "big-integer": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
-      "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM=",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+      "integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg=",
       "dev": true
     },
     "body-parser": {
@@ -1177,7 +1216,7 @@
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
       "dev": true,
       "requires": {
-        "big-integer": "1.6.25"
+        "big-integer": "1.6.26"
       }
     },
     "brace-expansion": {
@@ -1207,6 +1246,15 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "0.4.0"
+      }
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1232,6 +1280,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "caseless": {
@@ -1264,6 +1318,12 @@
         "supports-color": "2.0.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -1284,6 +1344,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
     },
     "clone": {
       "version": "1.0.3",
@@ -1310,14 +1381,13 @@
       "dev": true
     },
     "color": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+      "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
         "color-convert": "1.9.1",
-        "color-string": "0.3.0"
+        "color-string": "1.5.2"
       }
     },
     "color-convert": {
@@ -1336,12 +1406,13 @@
       "dev": true
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
       }
     },
     "colors": {
@@ -1586,6 +1657,17 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -2001,9 +2083,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.8.0.tgz",
-      "integrity": "sha512-SU3rfLI0XuUOD1O2QKIi3FE67rFQJMR0zkg/mRqwkrD5o35j8Xoa8QnRgeECY5mQWtCcOfQjAHn0qZ1qtPYpwA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.10.0.tgz",
+      "integrity": "sha512-7m6zSyFfEb3lAjZI217G1XVSAkYeFJHk2EqAVeoncrt+WtHddW4nnft2qPg82Xu1aB/T8nC/DPvkGgUUahli4g==",
       "dev": true,
       "requires": {
         "copy-paste": "1.3.0",
@@ -2081,12 +2163,12 @@
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz",
+      "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -2116,15 +2198,6 @@
           "requires": {
             "mime-types": "2.1.17",
             "negotiator": "0.6.1"
-          }
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
           }
         },
         "negotiator": {
@@ -2445,19 +2518,6 @@
         "p-finally": "1.0.0",
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        }
       }
     },
     "exit-hook": {
@@ -2534,13 +2594,13 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -2594,17 +2654,6 @@
       "dev": true,
       "requires": {
         "bser": "2.0.0"
-      },
-      "dependencies": {
-        "bser": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-          "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-          "dev": true,
-          "requires": {
-            "node-int64": "0.4.0"
-          }
-        }
       }
     },
     "fbjs": {
@@ -2619,6 +2668,30 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.17"
+      }
+    },
+    "fbjs-scripts": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.1.tgz",
+      "integrity": "sha512-hTjqlua9YJupF8shbVRTq20xKPITnDmqBLBQyR9BttZYT+gxGeKboIzPC19T3Erp29Q0+jdMwjUiyTHR61q1Bw==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-preset-fbjs": "2.1.4",
+        "core-js": "2.5.3",
+        "cross-spawn": "5.1.0",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "semver": "5.4.1",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "dev": true
+        }
       }
     },
     "figures": {
@@ -2774,17 +2847,6 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      },
-      "dependencies": {
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        }
       }
     },
     "fresh": {
@@ -2811,14 +2873,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -2976,7 +3038,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -3020,6 +3081,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3165,7 +3232,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -3337,11 +3403,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -3549,7 +3617,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -3958,14 +4025,14 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
           "dev": true,
           "requires": {
             "co": "4.6.0",
@@ -4099,6 +4166,12 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "image-size": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.1.tgz",
+      "integrity": "sha512-lHMlI2MykfeHAQdtydQh4fTcBQVf4zLTA91w1euBe9rbmAfJ/iyzMh8H3KD9u1RldlHaMS3tmMV5TEe9BkmW9g==",
       "dev": true
     },
     "imurmurhash": {
@@ -4392,6 +4465,26 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
+      "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+      "dev": true,
+      "requires": {
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "21.2.0",
+        "micromatch": "2.3.11",
+        "sane": "2.2.0",
+        "worker-farm": "1.5.2"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4413,12 +4506,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
-    },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "dev": true
     },
     "jsesc": {
       "version": "1.3.0",
@@ -4538,9 +4625,9 @@
       }
     },
     "left-pad": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
-      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
       "dev": true
     },
     "levn": {
@@ -4881,6 +4968,127 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "metro-bundler": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/metro-bundler/-/metro-bundler-0.20.3.tgz",
+      "integrity": "sha512-rKhIXSUEYbBUB9Ues30GYlcotM/4hPTmriBJGdNW5D+zdlxQUgJuPEo2Woo7khNM7xRG5tN7IRnMkKlzx43/Nw==",
+      "dev": true,
+      "requires": {
+        "absolute-path": "0.0.0",
+        "async": "2.6.0",
+        "babel-core": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-plugin-external-helpers": "6.22.0",
+        "babel-preset-es2015-node": "6.1.1",
+        "babel-preset-fbjs": "2.1.4",
+        "babel-preset-react-native": "4.0.0",
+        "babel-register": "6.26.0",
+        "babylon": "6.18.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "core-js": "2.5.3",
+        "debug": "2.6.9",
+        "denodeify": "1.2.1",
+        "fbjs": "0.8.16",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.6.1",
+        "jest-docblock": "21.2.0",
+        "jest-haste-map": "21.2.0",
+        "json-stable-stringify": "1.0.1",
+        "json5": "0.4.0",
+        "left-pad": "1.2.0",
+        "lodash": "4.17.4",
+        "merge-stream": "1.0.1",
+        "mime-types": "2.1.11",
+        "mkdirp": "0.5.1",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7",
+        "temp": "0.8.3",
+        "throat": "4.1.0",
+        "uglify-es": "3.2.2",
+        "wordwrap": "1.0.0",
+        "write-file-atomic": "1.3.4",
+        "xpipe": "1.0.5"
+      },
+      "dependencies": {
+        "babel-plugin-react-transform": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
+          "integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-preset-react-native": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
+          "integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-react-transform": "3.0.0",
+            "babel-plugin-syntax-async-functions": "6.13.0",
+            "babel-plugin-syntax-class-properties": "6.13.0",
+            "babel-plugin-syntax-dynamic-import": "6.18.0",
+            "babel-plugin-syntax-flow": "6.18.0",
+            "babel-plugin-syntax-jsx": "6.18.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-class-properties": "6.24.1",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-flow-strip-types": "6.22.0",
+            "babel-plugin-transform-object-assign": "6.22.0",
+            "babel-plugin-transform-object-rest-spread": "6.26.0",
+            "babel-plugin-transform-react-display-name": "6.25.0",
+            "babel-plugin-transform-react-jsx": "6.24.1",
+            "babel-plugin-transform-react-jsx-source": "6.22.0",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "babel-template": "6.26.0",
+            "react-transform-hmr": "1.0.4"
+          }
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+          "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.23.0"
+          }
+        }
+      }
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -4903,9 +5111,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -4915,20 +5123,12 @@
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-      "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.23.0"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.23.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-          "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
-          "dev": true
-        }
+        "mime-db": "1.30.0"
       }
     },
     "mimic-fn": {
@@ -5112,9 +5312,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -5379,6 +5579,17 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
     "os-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
@@ -5626,9 +5837,9 @@
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -5776,6 +5987,34 @@
       "integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw=",
       "dev": true
     },
+    "react-devtools-core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.5.2.tgz",
+      "integrity": "sha1-+XvsWvrl2TGNFneAZeDCFMTVcUw=",
+      "dev": true,
+      "requires": {
+        "shell-quote": "1.6.1",
+        "ws": "2.3.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        },
+        "ws": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1",
+            "ultron": "1.1.1"
+          }
+        }
+      }
+    },
     "react-dom": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
@@ -5789,9 +6028,9 @@
       }
     },
     "react-native": {
-      "version": "0.50.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.50.3.tgz",
-      "integrity": "sha1-kSgr1TVsx9eUlpzcRDzHZDibmvQ=",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.51.0.tgz",
+      "integrity": "sha512-XpLmz3C7DOds5TUwIOpQBEXqoFDtU2/HmMBzVItGlHtowXpcHoQxJYSxL4Z9u8B4EeDfSvGfU2TFHq0sV3xd3Q==",
       "dev": true,
       "requires": {
         "absolute-path": "0.0.0",
@@ -5800,6 +6039,7 @@
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
         "babel-plugin-transform-async-to-generator": "6.16.0",
         "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-flow-strip-types": "6.22.0",
         "babel-plugin-transform-object-rest-spread": "6.26.0",
         "babel-register": "6.26.0",
@@ -5811,7 +6051,7 @@
         "create-react-class": "15.6.2",
         "debug": "2.6.9",
         "denodeify": "1.2.1",
-        "envinfo": "3.8.0",
+        "envinfo": "3.10.0",
         "event-target-shim": "1.1.1",
         "fbjs": "0.8.16",
         "fbjs-scripts": "0.8.1",
@@ -5820,8 +6060,8 @@
         "graceful-fs": "4.1.11",
         "inquirer": "3.3.0",
         "lodash": "4.17.4",
-        "metro-bundler": "0.20.2",
-        "mime": "1.4.1",
+        "metro-bundler": "0.20.3",
+        "mime": "1.6.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
         "node-fetch": "1.7.3",
@@ -5836,7 +6076,7 @@
         "react-clone-referenced-element": "1.0.1",
         "react-devtools-core": "2.5.2",
         "react-timer-mixin": "0.13.3",
-        "regenerator-runtime": "0.9.6",
+        "regenerator-runtime": "0.11.0",
         "rimraf": "2.6.2",
         "semver": "5.4.1",
         "shell-quote": "1.6.1",
@@ -5869,60 +6109,6 @@
             "color-convert": "1.9.1"
           }
         },
-        "babel-plugin-react-transform": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
-          "integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-preset-react-native": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
-          "integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-react-transform": "3.0.0",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-plugin-syntax-class-properties": "6.13.0",
-            "babel-plugin-syntax-dynamic-import": "6.18.0",
-            "babel-plugin-syntax-flow": "6.18.0",
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-class-properties": "6.24.1",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-flow-strip-types": "6.22.0",
-            "babel-plugin-transform-object-assign": "6.22.0",
-            "babel-plugin-transform-object-rest-spread": "6.26.0",
-            "babel-plugin-transform-react-display-name": "6.25.0",
-            "babel-plugin-transform-react-jsx": "6.24.1",
-            "babel-plugin-transform-react-jsx-source": "6.22.0",
-            "babel-plugin-transform-regenerator": "6.26.0",
-            "babel-template": "6.26.0",
-            "react-transform-hmr": "1.0.4"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5930,87 +6116,6 @@
           "dev": true,
           "requires": {
             "restore-cursor": "2.0.0"
-          }
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            }
-          }
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
-        "fbjs-scripts": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.1.tgz",
-          "integrity": "sha512-hTjqlua9YJupF8shbVRTq20xKPITnDmqBLBQyR9BttZYT+gxGeKboIzPC19T3Erp29Q0+jdMwjUiyTHR61q1Bw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-preset-fbjs": "2.1.4",
-            "core-js": "2.5.1",
-            "cross-spawn": "5.1.0",
-            "gulp-util": "3.0.8",
-            "object-assign": "4.1.1",
-            "semver": "5.4.1",
-            "through2": "2.0.3"
           }
         },
         "figures": {
@@ -6028,12 +6133,6 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
-        "image-size": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.1.tgz",
-          "integrity": "sha512-lHMlI2MykfeHAQdtydQh4fTcBQVf4zLTA91w1euBe9rbmAfJ/iyzMh8H3KD9u1RldlHaMS3tmMV5TEe9BkmW9g==",
-          "dev": true
-        },
         "inquirer": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -6044,7 +6143,7 @@
             "chalk": "2.3.0",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
-            "external-editor": "2.0.5",
+            "external-editor": "2.1.0",
             "figures": "2.0.0",
             "lodash": "4.17.4",
             "mute-stream": "0.0.7",
@@ -6075,76 +6174,6 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "jest-docblock": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-          "dev": true
-        },
-        "jest-haste-map": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-          "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
-          "dev": true,
-          "requires": {
-            "fb-watchman": "2.0.0",
-            "graceful-fs": "4.1.11",
-            "jest-docblock": "21.2.0",
-            "micromatch": "2.3.11",
-            "sane": "2.2.0",
-            "worker-farm": "1.5.1"
-          }
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "metro-bundler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/metro-bundler/-/metro-bundler-0.20.2.tgz",
-          "integrity": "sha512-3kS3fDH7uj8nmS9C0swECFNFsuj5HrmzBxSTruzBuURAC0wzAX5NjU9N7Vaemp/pFS73nk5lvQ5Y5cKZxadcfg==",
-          "dev": true,
-          "requires": {
-            "absolute-path": "0.0.0",
-            "async": "2.6.0",
-            "babel-core": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-plugin-external-helpers": "6.22.0",
-            "babel-preset-es2015-node": "6.1.1",
-            "babel-preset-fbjs": "2.1.4",
-            "babel-preset-react-native": "4.0.0",
-            "babel-register": "6.26.0",
-            "babylon": "6.18.0",
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "core-js": "2.5.1",
-            "debug": "2.6.9",
-            "denodeify": "1.2.1",
-            "fbjs": "0.8.16",
-            "graceful-fs": "4.1.11",
-            "image-size": "0.6.1",
-            "jest-docblock": "21.2.0",
-            "jest-haste-map": "21.2.0",
-            "json-stable-stringify": "1.0.1",
-            "json5": "0.4.0",
-            "left-pad": "1.1.3",
-            "lodash": "4.17.4",
-            "merge-stream": "1.0.1",
-            "mime-types": "2.1.11",
-            "mkdirp": "0.5.1",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7",
-            "temp": "0.8.3",
-            "throat": "4.1.0",
-            "uglify-es": "3.1.8",
-            "wordwrap": "1.0.0",
-            "write-file-atomic": "1.3.4",
-            "xpipe": "1.0.5"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -6165,45 +6194,6 @@
           "requires": {
             "mimic-fn": "1.1.0"
           }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "react-devtools-core": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.5.2.tgz",
-          "integrity": "sha1-+XvsWvrl2TGNFneAZeDCFMTVcUw=",
-          "dev": true,
-          "requires": {
-            "shell-quote": "1.6.1",
-            "ws": "2.3.1"
-          },
-          "dependencies": {
-            "ws": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-              "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.0.1",
-                "ultron": "1.1.0"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
-          "dev": true
         },
         "restore-cursor": {
           "version": "2.0.0",
@@ -6229,28 +6219,6 @@
           "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
           "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
           "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "sane": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-          "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
-          "dev": true,
-          "requires": {
-            "anymatch": "1.3.2",
-            "exec-sh": "0.2.1",
-            "fb-watchman": "2.0.0",
-            "fsevents": "1.1.2",
-            "minimatch": "3.0.4",
-            "minimist": "1.2.0",
-            "walker": "1.0.7",
-            "watch": "0.18.0"
-          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -6280,63 +6248,21 @@
             "has-flag": "2.0.0"
           }
         },
-        "throat": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-          "dev": true
-        },
         "whatwg-fetch": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz",
           "integrity": "sha1-rDydOfMgxtzlM5lp0FTvQ90zMxk=",
           "dev": true
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
         }
       }
     },
     "react-native-svg": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-6.0.0.tgz",
-      "integrity": "sha1-Ai0/PWnQx1p7El1+lddhijEhYGo=",
+      "version": "6.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-6.0.1-rc.1.tgz",
+      "integrity": "sha512-tz8C2zdW6nASp5J2m6E6iMVlY0NgZAY7Nu3tQCoa9xqjkR65cdx/SjiFNY56e8IYYb3CScqULQeteOMv+ou4CA==",
       "dev": true,
       "requires": {
-        "color": "0.11.4",
+        "color": "2.0.1",
         "github-download": "0.5.0",
         "lodash": "4.17.4"
       }
@@ -6570,15 +6496,6 @@
         "uuid": "3.1.0"
       },
       "dependencies": {
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -6713,6 +6630,30 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "sane": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
+      "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "sax": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
@@ -6811,7 +6752,7 @@
         "debug": "2.2.0",
         "escape-html": "1.0.3",
         "http-errors": "1.3.1",
-        "mime-types": "2.1.11",
+        "mime-types": "2.1.17",
         "parseurl": "1.3.2"
       },
       "dependencies": {
@@ -6931,6 +6872,23 @@
           "version": "8.2.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+          "dev": true
+        }
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+          "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0=",
           "dev": true
         }
       }
@@ -7216,6 +7174,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7325,17 +7289,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
-      },
-      "dependencies": {
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        }
       }
     },
     "typedarray": {
@@ -7350,19 +7303,19 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "uglify-es": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.8.tgz",
-      "integrity": "sha512-z+rniTaxBFZngGxc93XAFwExhkWBtT2JlBVQDJ25D8pQD2Dlqf5sJg8ZhXMzK5xyu+hbUhuw52nUZD3+qqRmkQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+      "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
+        "commander": "2.12.2",
         "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
           "dev": true
         },
         "source-map": {
@@ -7383,9 +7336,9 @@
       }
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "underscore": {
@@ -7560,6 +7513,12 @@
         "isexe": "2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
     "win-release": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
@@ -7576,12 +7535,12 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz",
-      "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.5",
         "xtend": "4.0.1"
       }
     },
@@ -7713,6 +7672,69 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+      "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "mocha": "^3.0.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-native": "~0.50.0",
-    "react-native-svg": "^6.0.0",
+    "react-native": "~0.51.0",
+    "react-native-svg": "6.0.1-rc.1",
     "react-native-svg-mock": "^2.0.0",
     "react-test-renderer": "^16.0.0"
   },


### PR DESCRIPTION
with `react-native-svg@6.0.1-rc.1` it is no longer necessary to parse transforms, or use a matrix transformation for rotations about specified points. This PR removes code that is no longer necessary

**Requires `react-native-svg@6.0.1-rc.1` peer dependency**