### PR TITLE
fix circular clipPath

### DIFF
--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -22,14 +22,9 @@ export default class extends VictoryClipContainer {
 
   // Overrides method in victory-core
   renderClipComponent(props, clipId) {
-    const { clipPadding, translateX, translateY, clipHeight, clipWidth } = props;
     return (
       <ClipPath
-        clipPadding={clipPadding}
-        translateX={translateX}
-        translateY={translateY}
-        clipWidth={clipWidth}
-        clipHeight={clipHeight}
+        {...props}
         clipId={clipId}
       />
     );


### PR DESCRIPTION
This PR fixes https://github.com/FormidableLabs/victory-native/issues/148

`ClipPath` was not getting all the props it required to properly render the circular clip path used by `VictoryArea` when polar