### PR TITLE
Import from victory-*/es instead of victory-*/src

### DIFF
--- a/lib/components/victory-area.js
+++ b/lib/components/victory-area.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Dimensions } from "react-native";
-import { VictoryArea } from "victory-chart/src";
+import { VictoryArea } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-axis.js
+++ b/lib/components/victory-axis.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryAxis } from "victory-chart/src";
+import { VictoryAxis } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-bar.js
+++ b/lib/components/victory-bar.js
@@ -6,7 +6,7 @@ import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import { Bar } from "../index";
 
-import { VictoryBar } from "victory-chart/src";
+import { VictoryBar } from "victory-chart/es";
 
 export default class extends VictoryBar {
   static defaultProps = {

--- a/lib/components/victory-brush-container.js
+++ b/lib/components/victory-brush-container.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Rect, G } from "react-native-svg";
 import { last } from "lodash";
-import { BrushHelpers } from "victory-chart/src";
+import { BrushHelpers } from "victory-chart/es";
 import { VictoryContainer, NativeHelpers } from "../index";
 
 // ensure the selection component get native styles

--- a/lib/components/victory-candlestick.js
+++ b/lib/components/victory-candlestick.js
@@ -6,7 +6,7 @@ import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import { Candle } from "../index";
 
-import { VictoryCandlestick } from "victory-chart/src";
+import { VictoryCandlestick } from "victory-chart/es";
 
 export default class extends VictoryCandlestick {
   static defaultProps = {

--- a/lib/components/victory-chart.js
+++ b/lib/components/victory-chart.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryChart } from "victory-chart/src";
+import { VictoryChart } from "victory-chart/es";
 
 import VictoryAxis from "./victory-axis";
 import VictoryPolarAxis from "./victory-polar-axis";

--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { G } from "react-native-svg";
 import { NativeHelpers, ClipPath } from "../index";
-import { VictoryClipContainer } from "victory-core";
+import { VictoryClipContainer } from "victory-core/es";
 
 export default class extends VictoryClipContainer {
 

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -2,7 +2,7 @@ import React from "react";
 import Svg from "react-native-svg";
 import { assign, get, omit } from "lodash";
 import { View, PanResponder } from "react-native";
-import { VictoryContainer } from "victory-core/src";
+import { VictoryContainer } from "victory-core/es";
 
 import { NativeHelpers, Portal } from "../index";
 

--- a/lib/components/victory-cursor-container.js
+++ b/lib/components/victory-cursor-container.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { CursorHelpers } from "victory-chart/src";
+import { CursorHelpers } from "victory-chart/es";
 import { VictoryContainer, VictoryLabel, Line } from "../index";
 
 export const cursorContainerMixin = (base) => class VictoryNativeCursorContainer extends base { // eslint-disable-line max-len

--- a/lib/components/victory-errorbar.js
+++ b/lib/components/victory-errorbar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryErrorBar } from "victory-chart/src";
+import { VictoryErrorBar } from "victory-chart/es";
 
 import VictoryContainer from "./victory-container";
 import { ErrorBar } from "../index";

--- a/lib/components/victory-group.js
+++ b/lib/components/victory-group.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryGroup } from "victory-chart/src";
+import { VictoryGroup } from "victory-chart/es";
 
 import VictoryContainer from "./victory-container";
 

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text, TSpan } from "react-native-svg";
-import { VictoryLabel } from "victory-core/src";
+import { VictoryLabel } from "victory-core/es";
 
 import { NativeHelpers } from "../index";
 

--- a/lib/components/victory-legend.js
+++ b/lib/components/victory-legend.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { VictoryLegend } from "victory-core/src";
+import { VictoryLegend } from "victory-core/es";
 import { Dimensions } from "react-native";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-line.js
+++ b/lib/components/victory-line.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Dimensions } from "react-native";
-import { VictoryLine } from "victory-chart/src";
+import { VictoryLine } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-pie.js
+++ b/lib/components/victory-pie.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { VictoryPie } from "victory-pie/src";
+import { VictoryPie } from "victory-pie/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryPolarAxis } from "victory-chart/src";
+import { VictoryPolarAxis } from "victory-chart/es";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import { Line, Arc } from "../index";

--- a/lib/components/victory-portal/portal.js
+++ b/lib/components/victory-portal/portal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Svg from "react-native-svg";
-import { Portal } from "victory-core/src";
+import { Portal } from "victory-core/es";
 
 export default class extends Portal {
 

--- a/lib/components/victory-portal/victory-portal.js
+++ b/lib/components/victory-portal/victory-portal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { VictoryPortal } from "victory-core/src";
+import { VictoryPortal } from "victory-core/es";
 
 export default class extends VictoryPortal {
   renderPortal(child) {

--- a/lib/components/victory-primitives/arc.js
+++ b/lib/components/victory-primitives/arc.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Path } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Arc } from "victory-core";
+import { Arc } from "victory-core/es";
 
 export default class extends Arc {
   // Overridden in victory-core-native

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Path, G } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Area } from "victory-core";
+import { Area } from "victory-core/es";
 
 export default class extends Area {
 

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Path } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Bar } from "victory-core";
+import { Bar } from "victory-core/es";
 
 export default class extends Bar {
   // Overrides method in victory-core

--- a/lib/components/victory-primitives/border.js
+++ b/lib/components/victory-primitives/border.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Rect } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Border } from "victory-core";
+import { Border } from "victory-core/es";
 
 export default class extends Border {
   // Overrides method in victory-core

--- a/lib/components/victory-primitives/candle.js
+++ b/lib/components/victory-primitives/candle.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Line, Rect, G } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Candle } from "victory-core";
+import { Candle } from "victory-core/es";
 
 export default class extends Candle {
 

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { ClipPath as Clip, Rect, Defs, Circle } from "react-native-svg";
-import { ClipPath } from "victory-core";
+import { ClipPath } from "victory-core/es";
 
 export default class extends ClipPath {
   // Overrides method in victory-core

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Path, G } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Curve } from "victory-core";
+import { Curve } from "victory-core/es";
 
 export default class extends Curve {
   static defaultProps = {

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { G, Line } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { ErrorBar } from "victory-core";
+import { ErrorBar } from "victory-core/es";
 
 export default class extends ErrorBar {
 

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Path } from "react-native-svg";
-import { Flyout } from "victory-core";
+import { Flyout } from "victory-core/es";
 import { NativeHelpers } from "../../index";
 
 export default class extends Flyout {

--- a/lib/components/victory-primitives/line.js
+++ b/lib/components/victory-primitives/line.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Line } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Line as VLine } from "victory-core";
+import { Line as VLine } from "victory-core/es";
 
 export default class extends VLine {
   // Overrides method in victory-core

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Path } from "react-native-svg";
 import { NativeHelpers } from "../../index";
-import { Point } from "victory-core";
+import { Point } from "victory-core/es";
 
 export default class extends Point {
   // Overrides method in victory-core

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Path } from "react-native-svg";
-import { Slice } from "victory-core";
+import { Slice } from "victory-core/es";
 import { NativeHelpers } from "../../index";
 
 export default class extends Slice {

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Path, G, ClipPath, Defs } from "react-native-svg";
-import { Voronoi } from "victory-core";
+import { Voronoi } from "victory-core/es";
 import { NativeHelpers } from "../../index";
 
 export default class extends Voronoi {

--- a/lib/components/victory-scatter.js
+++ b/lib/components/victory-scatter.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryScatter } from "victory-chart/src";
+import { VictoryScatter } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-selection-container.js
+++ b/lib/components/victory-selection-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Rect } from "react-native-svg";
-import { SelectionHelpers } from "victory-chart/src";
+import { SelectionHelpers } from "victory-chart/es";
 import { VictoryContainer, NativeHelpers } from "../index";
 
 // ensure the selection component get native styles

--- a/lib/components/victory-stack.js
+++ b/lib/components/victory-stack.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryStack } from "victory-chart/src";
+import { VictoryStack } from "victory-chart/es";
 
 import VictoryContainer from "./victory-container";
 

--- a/lib/components/victory-tooltip.js
+++ b/lib/components/victory-tooltip.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { VictoryTooltip } from "victory-core/src";
+import { VictoryTooltip } from "victory-core/es";
 
 import VictoryLabel from "./victory-label";
 import { VictoryPortal, Flyout } from "../index";

--- a/lib/components/victory-voronoi-container.js
+++ b/lib/components/victory-voronoi-container.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { VoronoiHelpers } from "victory-chart/src";
+import { VoronoiHelpers } from "victory-chart/es";
 import { VictoryContainer, VictoryTooltip } from "../index";
 
 const onTouchStartOrMove = (evt, targetProps) => {

--- a/lib/components/victory-voronoi.js
+++ b/lib/components/victory-voronoi.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-import { VictoryVoronoi } from "victory-chart/src";
+import { VictoryVoronoi } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";

--- a/lib/helpers/create-container.js
+++ b/lib/helpers/create-container.js
@@ -5,7 +5,7 @@ import {
   brushContainerMixin as brushContainerMixinOriginal,
   cursorContainerMixin as cursorContainerMixinOriginal,
   makeCreateContainerFunction
-} from "victory-chart/src";
+} from "victory-chart/es";
 
 import { VictoryContainer } from "../index";
 

--- a/lib/helpers/native-zoom-helpers.js
+++ b/lib/helpers/native-zoom-helpers.js
@@ -1,7 +1,7 @@
 import { throttle, isFunction, defaults, isEqual } from "lodash";
 import { Dimensions } from "react-native";
-import { Collection } from "victory-core/src";
-import { RawZoomHelpers } from "victory-chart/src";
+import { Collection } from "victory-core/es";
+import { RawZoomHelpers } from "victory-chart/es";
 
 const hypotenuse = (x, y) => Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ export {
   VictorySharedEvents,
   VictoryTheme,
   VictoryTransition
-} from "victory-core";
+} from "victory-core/es";
 
 export { default as Arc } from "./components/victory-primitives/arc";
 export { default as Area } from "./components/victory-primitives/area";


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory-native/issues
 
`victory` deps are `victory-core`, `victory-chart`, and `victory-pie`, all of which output `es` modules.