### PR TITLE
refactor all primitive components

### DIFF
--- a/lib/components/victory-area.js
+++ b/lib/components/victory-area.js
@@ -8,12 +8,11 @@ import VictoryClipContainer from "./victory-clip-container";
 import { Area } from "../index";
 
 export default class extends VictoryArea {
-  static defaultProps = {
-    ...VictoryArea.defaultProps,
+  static defaultProps = Object.assign({}, VictoryArea.defaultProps, {
     dataComponent: <Area/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <VictoryClipContainer/>,
     width: Dimensions.get("window").width
-  }
+  });
 }

--- a/lib/components/victory-axis.js
+++ b/lib/components/victory-axis.js
@@ -8,8 +8,7 @@ import VictoryContainer from "./victory-container";
 import { Axis } from "../index";
 
 export default class extends VictoryAxis {
-  static defaultProps = {
-    ...VictoryAxis.defaultProps,
+  static defaultProps = Object.assign({}, VictoryAxis.defaultProps, {
     axisComponent: <Axis/>,
     axisLabelComponent: <VictoryLabel/>,
     tickLabelComponent: <VictoryLabel/>,
@@ -18,5 +17,5 @@ export default class extends VictoryAxis {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-axis.js
+++ b/lib/components/victory-axis.js
@@ -5,16 +5,16 @@ import { VictoryAxis } from "victory-chart/es";
 
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Line } from "../index";
+import { Axis } from "../index";
 
 export default class extends VictoryAxis {
   static defaultProps = {
     ...VictoryAxis.defaultProps,
-    axisComponent: <Line/>,
+    axisComponent: <Axis/>,
     axisLabelComponent: <VictoryLabel/>,
     tickLabelComponent: <VictoryLabel/>,
-    tickComponent: <Line/>,
-    gridComponent: <Line/>,
+    tickComponent: <Axis/>,
+    gridComponent: <Axis/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width

--- a/lib/components/victory-bar.js
+++ b/lib/components/victory-bar.js
@@ -9,12 +9,11 @@ import { Bar } from "../index";
 import { VictoryBar } from "victory-chart/es";
 
 export default class extends VictoryBar {
-  static defaultProps = {
-    ...VictoryBar.defaultProps,
+  static defaultProps = Object.assign({}, VictoryBar.defaultProps, {
     dataComponent: <Bar/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  }
+  });
 }

--- a/lib/components/victory-brush-container.js
+++ b/lib/components/victory-brush-container.js
@@ -14,8 +14,7 @@ RectWithStyle.propTypes = {
 };
 
 export const brushContainerMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
-  static defaultProps = {
-    ...VictoryContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
     selectionStyle: {
       stroke: "transparent",
       fill: "black",
@@ -28,7 +27,7 @@ export const brushContainerMixin = (base) => class VictoryNativeSelectionContain
     handleWidth: 8,
     brushComponent: <RectWithStyle/>,
     handleComponent: <RectWithStyle/>
-  };
+  });
 
   static defaultEvents = [{
     target: "parent",

--- a/lib/components/victory-candlestick.js
+++ b/lib/components/victory-candlestick.js
@@ -9,12 +9,11 @@ import { Candle } from "../index";
 import { VictoryCandlestick } from "victory-chart/es";
 
 export default class extends VictoryCandlestick {
-  static defaultProps = {
-    ...VictoryCandlestick.defaultProps,
+  static defaultProps = Object.assign({}, VictoryCandlestick.defaultProps, {
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  }
+  });
 }

--- a/lib/components/victory-chart.js
+++ b/lib/components/victory-chart.js
@@ -8,8 +8,7 @@ import VictoryPolarAxis from "./victory-polar-axis";
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryChart {
-  static defaultProps = {
-    ...VictoryChart.defaultProps,
+  static defaultProps = Object.assign({}, VictoryChart.defaultProps, {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     defaultAxes: {
@@ -21,5 +20,5 @@ export default class extends VictoryChart {
       dependent: <VictoryPolarAxis dependentAxis/>
     },
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -1,43 +1,14 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { NativeHelpers, ClipPath } from "../index";
+import { ClipPath, Circle, Rect } from "../index";
 import { VictoryClipContainer } from "victory-core/es";
 
 export default class extends VictoryClipContainer {
-
-  // Overrides method in victory-core
-  renderClippedGroup(props, clipId) {
-    const { style, events, children, className, transform } = props;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const clipComponent = this.renderClipComponent(props, clipId);
-    return (
-      <G {...nativeStyle} {...events} transform={transform} className={className}>
-        {clipComponent}
-        <G clipPath={`url(#${clipId})`}>
-          {children}
-        </G>
-      </G>
-    );
-  }
-
-  // Overrides method in victory-core
-  renderClipComponent(props, clipId) {
-    return (
-      <ClipPath
-        {...props}
-        clipId={clipId}
-      />
-    );
-  }
-
-  // Overrides method in victory-core
-  renderGroup(props) {
-    const { style, events, children, className, transform } = props;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    return (
-      <G {...nativeStyle} {...events} transform={transform} className={className}>
-        {children}
-      </G>
-    );
+  static defaultProps = {
+    ...VictoryClipContainer.defaultProps,
+    groupComponent: <G/>,
+    rectComponent: <Rect/>,
+    clipPathComponent: <ClipPath/>,
+    circleComponent: <Circle/>
   }
 }

--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -4,11 +4,10 @@ import { ClipPath, Circle, Rect } from "../index";
 import { VictoryClipContainer } from "victory-core/es";
 
 export default class extends VictoryClipContainer {
-  static defaultProps = {
-    ...VictoryClipContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryClipContainer.defaultProps, {
     groupComponent: <G/>,
     rectComponent: <Rect/>,
     clipPathComponent: <ClipPath/>,
     circleComponent: <Circle/>
-  }
+  });
 }

--- a/lib/components/victory-cursor-container.js
+++ b/lib/components/victory-cursor-container.js
@@ -3,15 +3,14 @@ import { CursorHelpers } from "victory-chart/es";
 import { VictoryContainer, VictoryLabel, Line } from "../index";
 
 export const cursorContainerMixin = (base) => class VictoryNativeCursorContainer extends base { // eslint-disable-line max-len
-  static defaultProps = {
-    ...VictoryContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
     cursorLabelComponent: <VictoryLabel/>,
     cursorLabelOffset: {
       x: 5,
       y: -10
     },
     cursorComponent: <Line/>
-  };
+  });
 
   static defaultEvents = [{
     target: "parent",

--- a/lib/components/victory-errorbar.js
+++ b/lib/components/victory-errorbar.js
@@ -7,11 +7,10 @@ import VictoryContainer from "./victory-container";
 import { ErrorBar } from "../index";
 
 export default class extends VictoryErrorBar {
-  static defaultProps = {
-    ...VictoryErrorBar.defaultProps,
+  static defaultProps = Object.assign({}, VictoryErrorBar.defaultProps, {
     dataComponent: <ErrorBar/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-group.js
+++ b/lib/components/victory-group.js
@@ -6,10 +6,9 @@ import { VictoryGroup } from "victory-chart/es";
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryGroup {
-  static defaultProps = {
-    ...VictoryGroup.defaultProps,
+  static defaultProps = Object.assign({}, VictoryGroup.defaultProps, {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -3,11 +3,8 @@ import { VictoryLabel } from "victory-core/es";
 import { Text, TSpan } from "../index";
 
 export default class extends VictoryLabel {
-  static defaultProps = {
-    ...VictoryLabel.defaultProps,
+  static defaultProps = Object.assign({}, VictoryLabel.defaultProps, {
     textComponent: <Text/>,
-    tspanComponent: <TSpan/>,
-    capHeight: 0.71,
-    lineHeight: 1
-  };
+    tspanComponent: <TSpan/>
+  });
 }

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,37 +1,13 @@
 import React from "react";
-import { Text, TSpan } from "react-native-svg";
 import { VictoryLabel } from "victory-core/es";
-
-import { NativeHelpers } from "../index";
+import { Text, TSpan } from "../index";
 
 export default class extends VictoryLabel {
   static defaultProps = {
     ...VictoryLabel.defaultProps,
+    textComponent: <Text/>,
+    tspanComponent: <TSpan/>,
     capHeight: 0.71,
     lineHeight: 1
   };
-
-  // Overrides method in victory-core
-  renderElements(props) {
-    const { className, events } = props;
-    const textProps = {
-      dx: this.dx, dy: this.dy, x: this.x, y: this.y, className, transform: this.transform
-    };
-    return (
-      <Text {...textProps} {...events}>
-        {this.content.map((line, i) => {
-          const style = NativeHelpers.getStyle(this.style[i] || this.style[0]);
-          const lastStyle = NativeHelpers.getStyle(this.style[i - 1] || this.style[0]);
-          const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
-          const textAnchor = style.textAnchor || this.textAnchor;
-          const dy = i ? (this.lineHeight * fontSize) : undefined;
-          return (
-            <TSpan key={i} x={this.x} dy={dy} dx={this.dx} {...style} textAnchor={textAnchor}>
-              {line}
-            </TSpan>
-          );
-        })}
-      </Text>
-    );
-  }
 }

--- a/lib/components/victory-legend.js
+++ b/lib/components/victory-legend.js
@@ -7,8 +7,7 @@ import VictoryContainer from "./victory-container";
 import { Point, Border } from "../index";
 
 export default class extends VictoryLegend {
-  static defaultProps = {
-    ...VictoryLegend.defaultProps,
+  static defaultProps = Object.assign({}, VictoryLegend.defaultProps, {
     borderComponent: <Border/>,
     containerComponent: <VictoryContainer/>,
     dataComponent: <Point/>,
@@ -16,5 +15,5 @@ export default class extends VictoryLegend {
     labelComponent: <VictoryLabel/>,
     titleComponent: <VictoryLabel/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-line.js
+++ b/lib/components/victory-line.js
@@ -8,12 +8,11 @@ import VictoryClipContainer from "./victory-clip-container";
 import { Curve } from "../index";
 
 export default class extends VictoryLine {
-  static defaultProps = {
-    ...VictoryLine.defaultProps,
+  static defaultProps = Object.assign({}, VictoryLine.defaultProps, {
     dataComponent: <Curve/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <VictoryClipContainer/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-pie.js
+++ b/lib/components/victory-pie.js
@@ -7,11 +7,10 @@ import VictoryContainer from "./victory-container";
 import { Slice } from "../index";
 
 export default class extends VictoryPie {
-  static defaultProps = {
-    ...VictoryPie.defaultProps,
+  static defaultProps = Object.assign({}, VictoryPie.defaultProps, {
     dataComponent: <Slice/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>
-  };
+  });
 }

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -7,8 +7,7 @@ import VictoryContainer from "./victory-container";
 import { Axis, Arc } from "../index";
 
 export default class extends VictoryPolarAxis {
-  static defaultProps = {
-    ...VictoryPolarAxis.defaultProps,
+  static defaultProps = Object.assign({}, VictoryPolarAxis.defaultProps, {
     axisComponent: <Axis/>,
     axisLabelComponent: <VictoryLabel/>,
     circularAxisComponent: <Arc type={"axis"}/>,
@@ -19,5 +18,5 @@ export default class extends VictoryPolarAxis {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -4,18 +4,18 @@ import { G } from "react-native-svg";
 import { VictoryPolarAxis } from "victory-chart/es";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Line, Arc } from "../index";
+import { Axis, Arc } from "../index";
 
 export default class extends VictoryPolarAxis {
   static defaultProps = {
     ...VictoryPolarAxis.defaultProps,
-    axisComponent: <Line/>,
+    axisComponent: <Axis/>,
     axisLabelComponent: <VictoryLabel/>,
     circularAxisComponent: <Arc type={"axis"}/>,
     circularGridComponent: <Arc type={"grid"}/>,
     tickLabelComponent: <VictoryLabel/>,
-    tickComponent: <Line/>,
-    gridComponent: <Line/>,
+    tickComponent: <Axis/>,
+    gridComponent: <Axis/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width

--- a/lib/components/victory-primitives/arc.js
+++ b/lib/components/victory-primitives/arc.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Arc } from "victory-core/es";
 
 export default class extends Arc {
-  static defaultProps = {
-    ...Arc.defaultProps,
+  static defaultProps = Object.assign({}, Arc.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/arc.js
+++ b/lib/components/victory-primitives/arc.js
@@ -1,23 +1,10 @@
 import React from "react";
-import { Path } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Path } from "../../index";
 import { Arc } from "victory-core/es";
 
 export default class extends Arc {
-  // Overridden in victory-core-native
-  renderAxisLine(props, style, events) {
-    const { role, shapeRendering, className } = props;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const path = this.getArcPath(props);
-    return (
-      <Path className={className}
-        d={path}
-        style={style}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Arc.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -4,9 +4,8 @@ import { G } from "react-native-svg";
 import { Area } from "victory-core/es";
 
 export default class extends Area {
-  static defaultProps = {
-    ...Area.defaultProps,
+  static defaultProps = Object.assign({}, Area.defaultProps, {
     groupComponent: <G/>,
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -1,53 +1,12 @@
 import React from "react";
-import { Path, G } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Path } from "../../index";
+import { G } from "react-native-svg";
 import { Area } from "victory-core/es";
 
 export default class extends Area {
-
   static defaultProps = {
-    groupComponent: <G/>
-  };
-
-  // Overrides method in victory-core
-  renderArea(path, style, events) {
-    const areaStroke = style.stroke ? "none" : style.fill;
-    const areaStyle = NativeHelpers.getStyle(Object.assign({}, style, { stroke: areaStroke }));
-    const { role, shapeRendering, className, polar, origin } = this.props;
-    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    return (
-      <Path
-        key={"area"}
-        shapeRendering={shapeRendering || "auto"}
-        role={role || "presentation"}
-        d={path}
-        className={className}
-        transform={transform}
-        {...areaStyle}
-        {...events}
-      />
-    );
-  }
-
-  // Overrides method in victory-core
-  renderLine(path, style, events) {
-    if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
-      return null;
-    }
-    const { role, shapeRendering, className, polar, origin } = this.props;
-    const lineStyle = NativeHelpers.getStyle(Object.assign({}, style, { fill: "none" }));
-    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    return (
-      <Path
-        key={"area-stroke"}
-        shapeRendering={shapeRendering || "auto"}
-        role={role || "presentation"}
-        d={path}
-        className={className}
-        transform={transform}
-        {...lineStyle}
-        {...events}
-      />
-    );
+    ...Area.defaultProps,
+    groupComponent: <G/>,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/axis.js
+++ b/lib/components/victory-primitives/axis.js
@@ -3,8 +3,7 @@ import { Line } from "../../index";
 import { Axis } from "victory-core/es";
 
 export default class extends Axis {
-  static defaultProps = {
-    ...Axis.defaultProps,
+  static defaultProps = Object.assign({}, Axis.defaultProps, {
     lineComponent: <Line/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/axis.js
+++ b/lib/components/victory-primitives/axis.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { Line } from "../../index";
+import { Axis } from "victory-core/es";
+
+export default class extends Axis {
+  static defaultProps = {
+    ...Axis.defaultProps,
+    lineComponent: <Line/>
+  }
+}

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Bar } from "victory-core/es";
 
 export default class extends Bar {
-  static defaultProps = {
-    ...Bar.defaultProps,
+  static defaultProps = Object.assign({}, Bar.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -1,24 +1,10 @@
 import React from "react";
-import { Path } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Path } from "../../index";
 import { Bar } from "victory-core/es";
 
 export default class extends Bar {
-  // Overrides method in victory-core
-  renderBar(path, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const { role, shapeRendering, className, polar, origin } = this.props;
-    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    return (
-      <Path
-        className={className}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        d={path}
-        transform={transform}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Bar.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/border.js
+++ b/lib/components/victory-primitives/border.js
@@ -3,8 +3,7 @@ import { Rect } from "../../index";
 import { Border } from "victory-core/es";
 
 export default class extends Border {
-  static defaultProps = {
-    ...Border.defaultProps,
+  static defaultProps = Object.assign({}, Border.defaultProps, {
     rectComponent: <Rect/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/border.js
+++ b/lib/components/victory-primitives/border.js
@@ -1,23 +1,10 @@
 import React from "react";
-import { Rect } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Rect } from "../../index";
 import { Border } from "victory-core/es";
 
 export default class extends Border {
-  // Overrides method in victory-core
-  renderBorder(props, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const { role, shapeRendering, className } = this.props;
-    return (
-      <Rect
-        {...props}
-        className={className}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        vectorEffect="non-scaling-stroke"
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Border.defaultProps,
+    rectComponent: <Rect/>
   }
 }

--- a/lib/components/victory-primitives/candle.js
+++ b/lib/components/victory-primitives/candle.js
@@ -4,10 +4,9 @@ import { G } from "react-native-svg";
 import { Candle } from "victory-core/es";
 
 export default class extends Candle {
-  static defaultProps = {
-    ...Candle.defaultProps,
+  static defaultProps = Object.assign({}, Candle.defaultProps, {
     groupComponent: <G/>,
     lineComponent: <Line/>,
     rectComponent: <Rect/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/candle.js
+++ b/lib/components/victory-primitives/candle.js
@@ -1,23 +1,13 @@
 import React from "react";
-import { Line, Rect, G } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Line, Rect } from "../../index";
+import { G } from "react-native-svg";
 import { Candle } from "victory-core/es";
 
 export default class extends Candle {
-
   static defaultProps = {
-    groupComponent: <G/>
-  };
-
-   // Overrides method in victory-core
-  renderWick(props) {
-    const nativeStyle = NativeHelpers.getStyle(props.style);
-    return <Line {...props} {...nativeStyle}/>;
-  }
-
-  // Overrides method in victory-core
-  renderCandle(props) {
-    const nativeStyle = NativeHelpers.getStyle(props.style);
-    return <Rect {...props} {...nativeStyle}/>;
+    ...Candle.defaultProps,
+    groupComponent: <G/>,
+    lineComponent: <Line/>,
+    rectComponent: <Rect/>
   }
 }

--- a/lib/components/victory-primitives/circle.js
+++ b/lib/components/victory-primitives/circle.js
@@ -1,33 +1,31 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Collection } from "victory-core";
-import { Line } from "react-native-svg";
+import { Circle } from "react-native-svg";
 import { NativeHelpers } from "../../index";
 
-export default class VLine extends React.Component {
+export default class VCircle extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     clipPath: PropTypes.string,
+    cx: PropTypes.number,
+    cy: PropTypes.number,
     events: PropTypes.object,
+    r: PropTypes.number,
     role: PropTypes.string,
     shapeRendering: PropTypes.string,
     style: PropTypes.object,
-    transform: PropTypes.string,
-    x1: PropTypes.number,
-    x2: PropTypes.number,
-    y1: PropTypes.number,
-    y2: PropTypes.number
+    transform: PropTypes.string
   };
 
   shouldComponentUpdate(nextProps) {
-    const { className, clipPath, x1, x2, y1, y2, style, transform } = this.props;
+    const { className, clipPath, cx, cy, r, transform, style } = this.props;
     if (!Collection.allSetsEqual([
       [className, nextProps.className],
       [clipPath, nextProps.clipPath],
-      [x1, nextProps.x1],
-      [x2, nextProps.x2],
-      [y1, nextProps.y1],
-      [y2, nextProps.y2],
+      [cx, nextProps.cx],
+      [cy, nextProps.cy],
+      [r, nextProps.r],
       [transform, nextProps.transform],
       [style, nextProps.style]
     ])) {
@@ -38,12 +36,12 @@ export default class VLine extends React.Component {
 
   render() {
     const {
-      x1, x2, y1, y2, events, className, clipPath, transform, shapeRendering, role
+      cx, cy, r, events, className, role, shapeRendering, transform, clipPath
     } = this.props;
     const style = NativeHelpers.getStyle(this.props.style);
     return (
-      <Line
-        x1={x1} x2={x2} y1={y1} y2={y2}
+      <Circle
+        cx={cx} cy={cy} r={r}
         className={className}
         clipPath={clipPath}
         transform={transform}

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -1,26 +1,23 @@
 import React from "react";
-import { ClipPath as Clip, Rect, Defs, Circle } from "react-native-svg";
-import { ClipPath } from "victory-core/es";
+import PropTypes from "prop-types";
+import { Defs, ClipPath } from "react-native-svg";
 
-export default class extends ClipPath {
-  // Overrides method in victory-core
-  renderClipPath(props, id) {
+export default class VClipPath extends React.Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]),
+    clipId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  };
+
+  render() {
+    const { children, clipId } = this.props;
     return (
       <Defs>
-        <Clip id={`${id}`}>
-          <Rect {...props}/>
-        </Clip>
-      </Defs>
-    );
-  }
-
-  // Overrides method in victory-core
-  renderPolarClipPath(props, id) {
-    return (
-      <Defs>
-        <Clip id={id}>
-          <Circle {...props}/>
-        </Clip>
+        <ClipPath id={clipId}>
+          {children}
+        </ClipPath>
       </Defs>
     );
   }

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Curve } from "victory-core/es";
 
 export default class extends Curve {
-  static defaultProps = {
-    ...Curve.defaultProps,
+  static defaultProps = Object.assign({}, Curve.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -1,29 +1,10 @@
 import React from "react";
-import { Path, G } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Path } from "../../index";
 import { Curve } from "victory-core/es";
 
 export default class extends Curve {
   static defaultProps = {
-    groupComponent: <G/>
-  };
-
-  // Overrides method in victory-core
-  renderLine(path, style, events) {
-    const { role, shapeRendering, className, polar, origin } = this.props;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const transform = polar && origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    return (
-      <Path
-        key={"curve"}
-        shapeRendering={shapeRendering || "auto"}
-        role={role || "presentation"}
-        d={path}
-        className={className}
-        transform={transform}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+    ...Curve.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -4,9 +4,8 @@ import { G } from "react-native-svg";
 import { ErrorBar } from "victory-core/es";
 
 export default class extends ErrorBar {
-  static defaultProps = {
-    ...ErrorBar.defaultProps,
+  static defaultProps = Object.assign({}, ErrorBar.defaultProps, {
     groupComponent: <G/>,
     lineComponent: <Line/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -1,18 +1,12 @@
 import React from "react";
-import { G, Line } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Line } from "../../index";
+import { G } from "react-native-svg";
 import { ErrorBar } from "victory-core/es";
 
 export default class extends ErrorBar {
-
   static defaultProps = {
-    borderWidth: 10,
-    groupComponent: <G/>
-  }
-
-  // Overrides method in victory-core
-  renderLine(props, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style);
-    return <Line {...props} {...nativeStyle} {...events}/>;
+    ...ErrorBar.defaultProps,
+    groupComponent: <G/>,
+    lineComponent: <Line/>
   }
 }

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -1,22 +1,10 @@
 import React from "react";
-import { Path } from "react-native-svg";
+import { Path } from "../../index";
 import { Flyout } from "victory-core/es";
-import { NativeHelpers } from "../../index";
 
 export default class extends Flyout {
-  // Overrides method in victory-core
-  renderFlyout(path, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const { role, shapeRendering, className } = this.props;
-    return (
-      <Path
-        className={className}
-        shapeRendering={shapeRendering || "auto"}
-        role={role || "presentation"}
-        d={path}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Flyout.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Flyout } from "victory-core/es";
 
 export default class extends Flyout {
-  static defaultProps = {
-    ...Flyout.defaultProps,
+  static defaultProps = Object.assign({}, Flyout.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/path.js
+++ b/lib/components/victory-primitives/path.js
@@ -1,33 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Collection } from "victory-core";
-import { Line } from "react-native-svg";
+import { Path } from "react-native-svg";
 import { NativeHelpers } from "../../index";
 
-export default class VLine extends React.Component {
+
+export default class VPath extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     clipPath: PropTypes.string,
+    d: PropTypes.string,
     events: PropTypes.object,
     role: PropTypes.string,
     shapeRendering: PropTypes.string,
     style: PropTypes.object,
-    transform: PropTypes.string,
-    x1: PropTypes.number,
-    x2: PropTypes.number,
-    y1: PropTypes.number,
-    y2: PropTypes.number
+    transform: PropTypes.string
   };
 
   shouldComponentUpdate(nextProps) {
-    const { className, clipPath, x1, x2, y1, y2, style, transform } = this.props;
+    const { className, clipPath, d, style, transform } = this.props;
     if (!Collection.allSetsEqual([
       [className, nextProps.className],
       [clipPath, nextProps.clipPath],
-      [x1, nextProps.x1],
-      [x2, nextProps.x2],
-      [y1, nextProps.y1],
-      [y2, nextProps.y2],
+      [d, nextProps.d],
       [transform, nextProps.transform],
       [style, nextProps.style]
     ])) {
@@ -37,19 +32,16 @@ export default class VLine extends React.Component {
   }
 
   render() {
-    const {
-      x1, x2, y1, y2, events, className, clipPath, transform, shapeRendering, role
-    } = this.props;
+    const { d, role, shapeRendering, className, clipPath, transform, events } = this.props;
     const style = NativeHelpers.getStyle(this.props.style);
     return (
-      <Line
-        x1={x1} x2={x2} y1={y1} y2={y2}
+      <Path
+        d={d}
+        transform={transform}
         className={className}
         clipPath={clipPath}
-        transform={transform}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
-        vectorEffect="non-scaling-stroke"
         {...style}
         {...events}
       />

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -1,22 +1,10 @@
 import React from "react";
-import { Path } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import { Path } from "../../index";
 import { Point } from "victory-core/es";
 
 export default class extends Point {
-  // Overrides method in victory-core
-  renderPoint(path, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const { role, shapeRendering, className } = this.props;
-    return (
-      <Path
-        className={className}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        d={path}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Point.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Point } from "victory-core/es";
 
 export default class extends Point {
-  static defaultProps = {
-    ...Point.defaultProps,
+  static defaultProps = Object.assign({}, Point.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/rect.js
+++ b/lib/components/victory-primitives/rect.js
@@ -1,33 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Collection } from "victory-core";
-import { Line } from "react-native-svg";
+import { Rect } from "react-native-svg";
 import { NativeHelpers } from "../../index";
 
-export default class VLine extends React.Component {
+export default class VRect extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     clipPath: PropTypes.string,
     events: PropTypes.object,
+    height: PropTypes.number,
     role: PropTypes.string,
+    rx: PropTypes.number,
+    ry: PropTypes.number,
     shapeRendering: PropTypes.string,
     style: PropTypes.object,
     transform: PropTypes.string,
-    x1: PropTypes.number,
-    x2: PropTypes.number,
-    y1: PropTypes.number,
-    y2: PropTypes.number
+    width: PropTypes.number,
+    x: PropTypes.number,
+    y: PropTypes.number
   };
 
   shouldComponentUpdate(nextProps) {
-    const { className, clipPath, x1, x2, y1, y2, style, transform } = this.props;
+    const { className, clipPath, x, y, rx, ry, width, height, transform, style } = this.props;
     if (!Collection.allSetsEqual([
       [className, nextProps.className],
+      [x, nextProps.x],
+      [y, nextProps.y],
+      [rx, nextProps.rx],
+      [ry, nextProps.ry],
+      [width, nextProps.width],
+      [height, nextProps.height],
       [clipPath, nextProps.clipPath],
-      [x1, nextProps.x1],
-      [x2, nextProps.x2],
-      [y1, nextProps.y1],
-      [y2, nextProps.y2],
       [transform, nextProps.transform],
       [style, nextProps.style]
     ])) {
@@ -38,12 +42,14 @@ export default class VLine extends React.Component {
 
   render() {
     const {
-      x1, x2, y1, y2, events, className, clipPath, transform, shapeRendering, role
+      x, y, rx, ry, width, height, events, className, clipPath, role,
+      shapeRendering, transform
     } = this.props;
     const style = NativeHelpers.getStyle(this.props.style);
+
     return (
-      <Line
-        x1={x1} x2={x2} y1={y1} y2={y2}
+      <Rect
+        x={x} y={y} rx={rx} ry={ry} width={width} height={height}
         className={className}
         clipPath={clipPath}
         transform={transform}

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -3,8 +3,7 @@ import { Path } from "../../index";
 import { Slice } from "victory-core/es";
 
 export default class extends Slice {
-  static defaultProps = {
-    ...Slice.defaultProps,
+  static defaultProps = Object.assign({}, Slice.defaultProps, {
     pathComponent: <Path/>
-  }
+  });
 }

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -1,24 +1,10 @@
 import React from "react";
-import { Path } from "react-native-svg";
+import { Path } from "../../index";
 import { Slice } from "victory-core/es";
-import { NativeHelpers } from "../../index";
 
 export default class extends Slice {
-  // Overrides method in victory-core
-  renderSlice(path, style, events) {
-    const { role, shapeRendering, className, origin } = this.props;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const transform = origin ? `translate(${origin.x} ${origin.y})` : undefined;
-    return (
-      <Path
-        className={className}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        d={path}
-        transform={transform}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Slice.defaultProps,
+    pathComponent: <Path/>
   }
 }

--- a/lib/components/victory-primitives/text.js
+++ b/lib/components/victory-primitives/text.js
@@ -1,0 +1,53 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Collection } from "victory-core";
+import { Text } from "react-native-svg";
+import { NativeHelpers } from "../../index";
+
+export default class VText extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    dx: PropTypes.number,
+    dy: PropTypes.number,
+    events: PropTypes.object,
+    style: PropTypes.object,
+    transform: PropTypes.string,
+    x: PropTypes.number,
+    y: PropTypes.number
+  };
+
+  shouldComponentUpdate(nextProps) {
+    const { className, x, y, dx, dy, transform, style, children } = this.props;
+    if (!Collection.allSetsEqual([
+      [className, nextProps.className],
+      [x, nextProps.x],
+      [y, nextProps.y],
+      [dx, nextProps.rx],
+      [dy, nextProps.ry],
+      [transform, nextProps.transform],
+      [style, nextProps.style],
+      [children, nextProps.children]
+    ])) {
+      return true;
+    }
+    return false;
+  }
+
+  render() {
+    const {
+      x, y, dx, dy, events, className, children, transform
+    } = this.props;
+    const style = NativeHelpers.getStyle(this.props.style);
+    return (
+      <Text
+        className={className} x={x} dx={dx} y={y} dy={dy}
+        transform={transform}
+        {...style}
+        {...events}
+      >
+        {children}
+      </Text>
+    );
+  }
+}

--- a/lib/components/victory-primitives/tspan.js
+++ b/lib/components/victory-primitives/tspan.js
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Collection } from "victory-core";
+import { TSpan } from "react-native-svg";
+import { NativeHelpers } from "../../index";
+
+
+export default class VTSpan extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    dx: PropTypes.number,
+    dy: PropTypes.number,
+    events: PropTypes.object,
+    style: PropTypes.object,
+    textAnchor: PropTypes.oneOf(["start", "middle", "end", "inherit"]),
+    x: PropTypes.number,
+    y: PropTypes.number
+  };
+
+  shouldComponentUpdate(nextProps) {
+    const { className, x, y, dx, dy, textAnchor, style, content } = this.props;
+    if (!Collection.allSetsEqual([
+      [className, nextProps.className],
+      [content, nextProps.content],
+      [x, nextProps.x],
+      [y, nextProps.y],
+      [dx, nextProps.rx],
+      [dy, nextProps.ry],
+      [textAnchor, nextProps.textAnchor],
+      [style, nextProps.style]
+    ])) {
+      return true;
+    }
+    return false;
+  }
+
+  render() {
+    const { x, y, dx, dy, events, className, textAnchor, content } = this.props;
+    const style = NativeHelpers.getStyle(this.props.style);
+    return (
+      <TSpan
+        x={x} y={y} dx={dx} dy={dy} textAnchor={textAnchor}
+        className={className}
+        {...style}
+        {...events}
+      >
+        {content}
+      </TSpan>
+    );
+  }
+}

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -1,41 +1,14 @@
 import React from "react";
-import { Path, G, ClipPath, Defs } from "react-native-svg";
+import { Path, ClipPath, Circle } from "../../index";
+import { G } from "react-native-svg";
 import { Voronoi } from "victory-core/es";
-import { NativeHelpers } from "../../index";
 
 export default class extends Voronoi {
-  // Overrides method in victory-core
-  renderPoint(paths, style, events) {
-    const clipId = `clipPath-${Math.random()}`;
-    const nativeStyle = NativeHelpers.getStyle(style);
-    const { className, role, shapeRendering } = this.props;
-    return paths.circle ?
-      (
-        <G>
-          <Defs>
-            <ClipPath id={clipId}>
-              <Path d={paths.voronoi}/>
-            </ClipPath>
-          </Defs>
-          <Path
-            d={paths.circle}
-            className={className}
-            role={role || "presentation"}
-            shapeRendering={shapeRendering || "auto"}
-            clipPath={`url(#${clipId})`}
-            {...nativeStyle}
-            {...events}
-          />
-        </G>
-      ) : (
-      <Path
-        className={className}
-        role={role || "presentation"}
-        shapeRendering={shapeRendering || "auto"}
-        d={paths.voronoi}
-        {...nativeStyle}
-        {...events}
-      />
-    );
+  static defaultProps = {
+    ...Voronoi.defaultProps,
+    groupComponent: <G/>,
+    pathComponent: <Path/>,
+    clipPathComponent: <ClipPath/>,
+    circleComponent: <Circle/>
   }
 }

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -4,11 +4,10 @@ import { G } from "react-native-svg";
 import { Voronoi } from "victory-core/es";
 
 export default class extends Voronoi {
-  static defaultProps = {
-    ...Voronoi.defaultProps,
+  static defaultProps = Object.assign({}, Voronoi.defaultProps, {
     groupComponent: <G/>,
     pathComponent: <Path/>,
     clipPathComponent: <ClipPath/>,
     circleComponent: <Circle/>
-  }
+  });
 }

--- a/lib/components/victory-scatter.js
+++ b/lib/components/victory-scatter.js
@@ -8,12 +8,11 @@ import VictoryContainer from "./victory-container";
 import { Point } from "../index";
 
 export default class extends VictoryScatter {
-  static defaultProps = {
-    ...VictoryScatter.defaultProps,
+  static defaultProps = Object.assign({}, VictoryScatter.defaultProps, {
     dataComponent: <Point/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-selection-container.js
+++ b/lib/components/victory-selection-container.js
@@ -13,8 +13,7 @@ DefaultSelectionComponent.propTypes = {
 };
 
 export const selectionContainerMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
-  static defaultProps = {
-    ...VictoryContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
     selectionStyle: {
       stroke: "transparent",
       fill: "black",
@@ -22,7 +21,7 @@ export const selectionContainerMixin = (base) => class VictoryNativeSelectionCon
     },
     standalone: true,
     selectionComponent: <DefaultSelectionComponent />
-  };
+  });
 
   static defaultEvents = [{
     target: "parent",

--- a/lib/components/victory-stack.js
+++ b/lib/components/victory-stack.js
@@ -6,10 +6,9 @@ import { VictoryStack } from "victory-chart/es";
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryStack {
-  static defaultProps = {
-    ...VictoryStack.defaultProps,
+  static defaultProps = Object.assign({}, VictoryStack.defaultProps, {
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-tooltip.js
+++ b/lib/components/victory-tooltip.js
@@ -6,12 +6,11 @@ import VictoryLabel from "./victory-label";
 import { VictoryPortal, Flyout } from "../index";
 
 export default class extends VictoryTooltip {
-  static defaultProps = {
-    ...VictoryTooltip.defaultProps,
+  static defaultProps = Object.assign({}, VictoryTooltip.defaultProps, {
     labelComponent: <VictoryLabel/>,
     flyoutComponent: <Flyout/>,
     groupComponent: <G/>
-  };
+  });
 
   static defaultEvents = [{
     target: "data",

--- a/lib/components/victory-voronoi-container.js
+++ b/lib/components/victory-voronoi-container.js
@@ -14,12 +14,11 @@ const onTouchStartOrMove = (evt, targetProps) => {
 };
 
 export const voronoiContainerMixin = (base) => class VictoryNativeVoronoiContainer extends base {
-  static defaultProps = {
-    ...VictoryContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
     standalone: true,
     labelComponent: <VictoryTooltip/>,
     voronoiPadding: 5
-  };
+  });
 
   static defaultEvents = [{
     target: "parent",

--- a/lib/components/victory-voronoi.js
+++ b/lib/components/victory-voronoi.js
@@ -8,12 +8,11 @@ import VictoryContainer from "./victory-container";
 import { Voronoi } from "../index";
 
 export default class extends VictoryVoronoi {
-  static defaultProps = {
-    ...VictoryVoronoi.defaultProps,
+  static defaultProps = Object.assign({}, VictoryVoronoi.defaultProps, {
     dataComponent: <Voronoi/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width
-  };
+  });
 }

--- a/lib/components/victory-zoom-container.js
+++ b/lib/components/victory-zoom-container.js
@@ -2,13 +2,12 @@ import React from "react";
 import { VictoryContainer, VictoryClipContainer, NativeZoomHelpers } from "../index";
 
 export const zoomContainerMixin = (base) => class VictoryNativeZoomContainer extends base {
-  static defaultProps = {
-    ...VictoryContainer.defaultProps,
+  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
     clipContainerComponent: <VictoryClipContainer/>,
     allowZoom: true,
     allowPan: true,
     zoomActive: false
-  };
+  });
 
   static defaultEvents = [{
     target: "parent",

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,15 +7,21 @@ export {
   VictoryTransition
 } from "victory-core/es";
 
+export { default as Circle } from "./components/victory-primitives/line";
+export { default as Line } from "./components/victory-primitives/line";
+export { default as Path } from "./components/victory-primitives/path";
+export { default as Rect } from "./components/victory-primitives/rect";
+export { default as Text } from "./components/victory-primitives/text";
+export { default as TSpan } from "./components/victory-primitives/tspan";
 export { default as Arc } from "./components/victory-primitives/arc";
 export { default as Area } from "./components/victory-primitives/area";
 export { default as Bar } from "./components/victory-primitives/bar";
-export { default as Border } from "./components/victory-primitives/border";
+export { default as Border, default as Box } from "./components/victory-primitives/border";
 export { default as Candle } from "./components/victory-primitives/candle";
 export { default as ClipPath } from "./components/victory-primitives/clip-path";
 export { default as Curve } from "./components/victory-primitives/curve";
 export { default as ErrorBar } from "./components/victory-primitives/error-bar";
-export { default as Line } from "./components/victory-primitives/line";
+export { default as Axis, default as Grid } from "./components/victory-primitives/line";
 export { default as Point } from "./components/victory-primitives/point";
 export { default as Slice } from "./components/victory-primitives/slice";
 export { default as Voronoi } from "./components/victory-primitives/voronoi";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "victory-native",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7420,19 +7420,19 @@
       "dev": true
     },
     "victory-chart": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-24.3.0.tgz",
-      "integrity": "sha512-YKLxo6v4ohg0thpw4UgJKlCriiG60bp2VAuIuDk//zlCANQqL9xDADnc5yA7rIHpYXpZzm1tpqntTeC+tTB+BA==",
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-25.0.2.tgz",
+      "integrity": "sha512-ELJ66NtY/Sp8IVcfOzhMxo00luZB5vbfb6WFLcPO1pnX5XIphyPexHYNWm+ZyX1nN+dJ3ZMHicXKG/M7DXkLww==",
       "requires": {
         "d3-voronoi": "1.1.2",
         "lodash": "4.17.4",
-        "victory-core": "20.2.0"
+        "victory-core": "21.0.2"
       }
     },
     "victory-core": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.2.0.tgz",
-      "integrity": "sha1-86Mfyd5jUTrqC7ubA9t40b6/zBM=",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-21.0.2.tgz",
+      "integrity": "sha512-+uSieMgKPDtYPrISW9/b0eauKXXslhwIrvjgCydKmzsxoL24lA3ej50/jYfW7xyqrhcx0gRZA7IuYuZWIYxf6w==",
       "requires": {
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.5",
@@ -7443,13 +7443,13 @@
       }
     },
     "victory-pie": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-13.1.0.tgz",
-      "integrity": "sha512-Sh/vn3XPYG4mXg/CqODbixBKdq2r7X0FFBKEG1Y5V6MQliLcrmbvwD68H+PX0V5ksRL9GxtNX2lmLiQhJZ/JAw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-14.0.1.tgz",
+      "integrity": "sha512-tPKWMkNPHgC3k57Ib6EwFkP5M2nI0ZWlkU7hWxwCRb0XN657BUGOcLbw11TsnuDAkNPSL5q7Hya39Soz/27qwA==",
       "requires": {
         "d3-shape": "1.2.0",
         "lodash": "4.17.4",
-        "victory-core": "20.2.0"
+        "victory-core": "21.0.2"
       }
     },
     "vinyl": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "victory-chart": "^24.3.0",
-    "victory-core": "^20.2.0",
-    "victory-pie": "^13.0.0"
+    "victory-chart": "^25.0.2",
+    "victory-core": "^21.0.2",
+    "victory-pie": "^14.0.0"
   }
 }


### PR DESCRIPTION
After this refactor the a handful of files that have any code in them other than extending the original and altering `defaultProps`

Very primitive components:
- `victory-primitives/circle.js`
- `victory-primitives/clip-path.js`
- `victory-primitives/line.js`
- `victory-primitives/path.js`
- `victory-primitives/rect.js`
- `victory-primitives/text.js`
- `victory-primitives/tspan.js`

Container components and components with defaultEvents
- `victory-container.js`
- `victory-*-container.js`
- `victory-tooltip.js`

Portal components
- `victory-portal/victory-portal.js`
- `victory-portal/portal.js`

Helpers
- `helpers/create-container.js`
- `helpers/native-helpers.js`
- `helpers/native-zoom-helpers.js`