### PR TITLE
refactor native container mixins

### DIFF
--- a/lib/components/victory-area.js
+++ b/lib/components/victory-area.js
@@ -5,7 +5,7 @@ import { VictoryArea } from "victory-area/es";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import VictoryClipContainer from "./victory-clip-container";
-import { Area } from "../index";
+import Area from "./victory-primitives/area";
 
 export default class extends VictoryArea {
   static defaultProps = Object.assign({}, VictoryArea.defaultProps, {

--- a/lib/components/victory-axis.js
+++ b/lib/components/victory-axis.js
@@ -2,10 +2,9 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryAxis } from "victory-axis/es";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { LineSegment } from "../index";
+import LineSegment from "./victory-primitives/line-segment";
 
 export default class extends VictoryAxis {
   static defaultProps = Object.assign({}, VictoryAxis.defaultProps, {

--- a/lib/components/victory-bar.js
+++ b/lib/components/victory-bar.js
@@ -1,11 +1,9 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Bar } from "../index";
-
+import Bar from "./victory-primitives/bar";
 import { VictoryBar } from "victory-bar/es";
 
 export default class extends VictoryBar {

--- a/lib/components/victory-boxplot.js
+++ b/lib/components/victory-boxplot.js
@@ -2,10 +2,11 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryBoxPlot } from "victory-box-plot/es";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Box, Whisker, LineSegment } from "../index";
+import Border from "./victory-primitives/border";
+import Whisker from "./victory-primitives/whisker";
+import LineSegment from "./victory-primitives/line-segment";
 
 export default class extends VictoryBoxPlot {
   static defaultProps = Object.assign({}, VictoryBoxPlot.defaultProps, {
@@ -15,9 +16,9 @@ export default class extends VictoryBoxPlot {
     medianLabelComponent: <VictoryLabel/>,
     minComponent: <Whisker/>,
     minLabelComponent: <VictoryLabel/>,
-    q1Component: <Box/>,
+    q1Component: <Border/>,
     q1LabelComponent: <VictoryLabel/>,
-    q3Component: <Box/>,
+    q3Component: <Border/>,
     q3LabelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,

--- a/lib/components/victory-brush-container.js
+++ b/lib/components/victory-brush-container.js
@@ -2,8 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Rect, G } from "react-native-svg";
 import { last } from "lodash";
-import { BrushHelpers } from "victory-brush-container/es";
-import { VictoryContainer, NativeHelpers } from "../index";
+import { BrushHelpers } from "victory-brush-container";
+import VictoryContainer from "./victory-container";
+import NativeHelpers from "../helpers/native-helpers";
 
 // ensure the selection component get native styles
 const RectWithStyle = ({ style, ...otherProps }) =>

--- a/lib/components/victory-brush-container.js
+++ b/lib/components/victory-brush-container.js
@@ -1,8 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Rect, G } from "react-native-svg";
-import { last } from "lodash";
-import { BrushHelpers } from "victory-brush-container";
+import { flow, defaults, isEqual } from "lodash";
+import {
+   VictoryBrushContainer, BrushHelpers, brushContainerMixin as originalBrushMixin
+} from "victory-brush-container";
+import { Selection } from "victory-core";
 import VictoryContainer from "./victory-container";
 import NativeHelpers from "../helpers/native-helpers";
 
@@ -14,22 +17,15 @@ RectWithStyle.propTypes = {
   style: PropTypes.object
 };
 
-export const brushContainerMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
-  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
-    selectionStyle: {
-      stroke: "transparent",
-      fill: "black",
-      fillOpacity: 0.1
-    },
-    handleStyle: {
-      stroke: "transparent",
-      fill: "transparent"
-    },
-    handleWidth: 8,
+const nativeBrushMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
+  // assign native specific defaultProps over web `VictoryBrushContainer` defaultProps
+  static defaultProps = {
+    ...VictoryBrushContainer.defaultProps,
     brushComponent: <RectWithStyle/>,
     handleComponent: <RectWithStyle/>
-  });
+  };
 
+  // overrides all web events with native specific events
   static defaultEvents = (props) => {
     return [{
       target: "parent",
@@ -55,17 +51,27 @@ export const brushContainerMixin = (base) => class VictoryNativeSelectionContain
     }];
   };
 
-  getChildren(props) {
-    const { children } = props; // eslint-disable-line react/prop-types
-    const lastChild = last(children);
-    // replace the web's getChildren's <g> with <G> from react-native-svg
-    if (lastChild && lastChild.type === "g") {
-      children[children.length - 1] = (
-        <G key="brush-group">
-          {lastChild.props.children}
+  // override method in `VictoryBrushContainer` and change <g> to <G>
+  // TODO: add a `groupComponent` prop to `VictoryBrushContainer` instead
+  getRect(props) {
+    const { currentDomain, cachedBrushDomain } = props;
+    const brushDomain = defaults({}, props.brushDomain, props.domain);
+    const domain = isEqual(brushDomain, cachedBrushDomain) ?
+      defaults({}, currentDomain, brushDomain) : brushDomain;
+    const coordinates = Selection.getDomainCoordinates(props, domain);
+    const selectBox = this.getSelectBox(props, coordinates);
+    return selectBox ?
+      (
+        <G>
+          {selectBox}
+          {this.getHandles(props, coordinates)}
         </G>
-      );
-    }
-    return children;
+      ) : null;
   }
 };
+
+const combinedMixin = flow(originalBrushMixin, nativeBrushMixin);
+
+export const brushContainerMixin = (base) => combinedMixin(base);
+
+export default brushContainerMixin(VictoryContainer);

--- a/lib/components/victory-candlestick.js
+++ b/lib/components/victory-candlestick.js
@@ -1,11 +1,9 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Candle } from "../index";
-
+import Candle from "./victory-primitives/candle";
 import { VictoryCandlestick } from "victory-candlestick/es";
 
 export default class extends VictoryCandlestick {

--- a/lib/components/victory-chart.js
+++ b/lib/components/victory-chart.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryChart } from "victory-chart/es";
-
 import VictoryAxis from "./victory-axis";
 import VictoryPolarAxis from "./victory-polar-axis";
 import VictoryContainer from "./victory-container";

--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { G } from "react-native-svg";
-import { ClipPath, Circle, Rect } from "../index";
+import Circle from "./victory-primitives/circle";
+import Rect from "./victory-primitives/rect";
+import ClipPath from "./victory-primitives/clip-path";
 import { VictoryClipContainer } from "victory-core/es";
 
 export default class extends VictoryClipContainer {

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -3,8 +3,8 @@ import Svg from "react-native-svg";
 import { assign, get } from "lodash";
 import { View, PanResponder } from "react-native";
 import { VictoryContainer } from "victory-core/es";
-
-import { NativeHelpers, Portal } from "../index";
+import NativeHelpers from "../helpers/native-helpers";
+import Portal from "./victory-portal/portal";
 
 export default class extends VictoryContainer {
   constructor(props) {

--- a/lib/components/victory-cursor-container.js
+++ b/lib/components/victory-cursor-container.js
@@ -1,19 +1,22 @@
 import React from "react";
-import { CursorHelpers } from "victory-cursor-container/es";
+import { flow } from "lodash";
+import {
+  VictoryCursorContainer, CursorHelpers, cursorContainerMixin as originalCursorMixin
+} from "victory-cursor-container";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import LineSegment from "./victory-primitives/line-segment";
 
-export const cursorContainerMixin = (base) => class VictoryNativeCursorContainer extends base { // eslint-disable-line max-len
-  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
+const nativeCursorMixin = (base) => class VictoryNativeCursorContainer extends base {
+  static displayName = "VictoryCursorContainer";
+  // assign native specific defaultProps over web `VictoryCursorContainer` defaultProps
+  static defaultProps = {
+    ...VictoryCursorContainer.defaultProps,
     cursorLabelComponent: <VictoryLabel/>,
-    cursorLabelOffset: {
-      x: 5,
-      y: -10
-    },
     cursorComponent: <LineSegment/>
-  });
+  };
 
+  // overrides all web events with native specific events
   static defaultEvents = (props) => {
     return [{
       target: "parent",
@@ -27,7 +30,10 @@ export const cursorContainerMixin = (base) => class VictoryNativeCursorContainer
       }
     }];
   };
-
-  // pass through, so the original container mixin isn't applied twice by combineContainerMixins
-  getChildren({ children }) { return children; }
 };
+
+const combinedMixin = flow(originalCursorMixin, nativeCursorMixin);
+
+export const cursorContainerMixin = (base) => combinedMixin(base);
+
+export default cursorContainerMixin(VictoryContainer);

--- a/lib/components/victory-cursor-container.js
+++ b/lib/components/victory-cursor-container.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { CursorHelpers } from "victory-cursor-container/es";
-import { VictoryContainer, VictoryLabel, LineSegment } from "../index";
+import VictoryLabel from "./victory-label";
+import VictoryContainer from "./victory-container";
+import LineSegment from "./victory-primitives/line-segment";
 
 export const cursorContainerMixin = (base) => class VictoryNativeCursorContainer extends base { // eslint-disable-line max-len
   static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {

--- a/lib/components/victory-errorbar.js
+++ b/lib/components/victory-errorbar.js
@@ -2,9 +2,8 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryErrorBar } from "victory-errorbar/es";
-
 import VictoryContainer from "./victory-container";
-import { ErrorBar } from "../index";
+import ErrorBar from "./victory-primitives/error-bar";
 
 export default class extends VictoryErrorBar {
   static defaultProps = Object.assign({}, VictoryErrorBar.defaultProps, {

--- a/lib/components/victory-group.js
+++ b/lib/components/victory-group.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryGroup } from "victory-group/es";
-
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryGroup {

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { VictoryLabel } from "victory-core/es";
-import { Text, TSpan } from "../index";
+import Text from "./victory-primitives/text";
+import TSpan from "./victory-primitives/tspan";
 
 export default class extends VictoryLabel {
   static defaultProps = Object.assign({}, VictoryLabel.defaultProps, {

--- a/lib/components/victory-legend.js
+++ b/lib/components/victory-legend.js
@@ -4,7 +4,8 @@ import { VictoryLegend } from "victory-legend/es";
 import { Dimensions } from "react-native";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Point, Border } from "../index";
+import Point from "./victory-primitives/point";
+import Border from "./victory-primitives/border";
 
 export default class extends VictoryLegend {
   static defaultProps = Object.assign({}, VictoryLegend.defaultProps, {

--- a/lib/components/victory-line.js
+++ b/lib/components/victory-line.js
@@ -1,11 +1,10 @@
 import React from "react";
 import { Dimensions } from "react-native";
 import { VictoryLine } from "victory-line/es";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
 import VictoryClipContainer from "./victory-clip-container";
-import { Curve } from "../index";
+import Curve from "./victory-primitives/curve";
 
 export default class extends VictoryLine {
   static defaultProps = Object.assign({}, VictoryLine.defaultProps, {

--- a/lib/components/victory-pie.js
+++ b/lib/components/victory-pie.js
@@ -4,7 +4,7 @@ import { G } from "react-native-svg";
 import { VictoryPie } from "victory-pie/es";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Slice } from "../index";
+import Slice from "./victory-primitives/slice";
 
 export default class extends VictoryPie {
   static defaultProps = Object.assign({}, VictoryPie.defaultProps, {

--- a/lib/components/victory-polar-axis.js
+++ b/lib/components/victory-polar-axis.js
@@ -4,7 +4,8 @@ import { G } from "react-native-svg";
 import { VictoryPolarAxis } from "victory-polar-axis/es";
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Arc, LineSegment } from "../index";
+import Arc from "./victory-primitives/arc";
+import LineSegment from "./victory-primitives/line-segment";
 
 export default class extends VictoryPolarAxis {
   static defaultProps = Object.assign({}, VictoryPolarAxis.defaultProps, {

--- a/lib/components/victory-primitives/arc.js
+++ b/lib/components/victory-primitives/arc.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Arc } from "victory-core/es";
 
 export default class extends Arc {

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { G } from "react-native-svg";
 import { Area } from "victory-area/es";
 

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Bar } from "victory-bar/es";
 
 export default class extends Bar {

--- a/lib/components/victory-primitives/border.js
+++ b/lib/components/victory-primitives/border.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Rect } from "../../index";
+import Rect from "./rect";
 import { Border } from "victory-core/es";
 
 export default class extends Border {

--- a/lib/components/victory-primitives/candle.js
+++ b/lib/components/victory-primitives/candle.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Line, Rect } from "../../index";
+import Line from "./line";
+import Rect from "./rect";
 import { G } from "react-native-svg";
 import { Candle } from "victory-candlestick/es";
 

--- a/lib/components/victory-primitives/circle.js
+++ b/lib/components/victory-primitives/circle.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { Circle } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VCircle extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Curve } from "victory-line/es";
 
 export default class extends Curve {

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Line } from "../../index";
+import Line from "./line";
 import { G } from "react-native-svg";
 import { ErrorBar } from "victory-errorbar/es";
 

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Flyout } from "victory-tooltip/es";
 
 export default class extends Flyout {

--- a/lib/components/victory-primitives/line-segment.js
+++ b/lib/components/victory-primitives/line-segment.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Line } from "../..";
+import Line from "./line";
 import { LineSegment } from "victory-core/es";
 
 export default class extends LineSegment {

--- a/lib/components/victory-primitives/line.js
+++ b/lib/components/victory-primitives/line.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { Line } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VLine extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/path.js
+++ b/lib/components/victory-primitives/path.js
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { Path } from "react-native-svg";
-import { NativeHelpers } from "../../index";
-
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VPath extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Point } from "victory-core/es";
 
 export default class extends Point {

--- a/lib/components/victory-primitives/rect.js
+++ b/lib/components/victory-primitives/rect.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { Rect } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VRect extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Path } from "../../index";
+import Path from "./path";
 import { Slice } from "victory-pie/es";
 
 export default class extends Slice {

--- a/lib/components/victory-primitives/text.js
+++ b/lib/components/victory-primitives/text.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { Text } from "react-native-svg";
-import { NativeHelpers } from "../../index";
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VText extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/tspan.js
+++ b/lib/components/victory-primitives/tspan.js
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "react-fast-compare";
 import { TSpan } from "react-native-svg";
-import { NativeHelpers } from "../../index";
-
+import NativeHelpers from "../../helpers/native-helpers";
 
 export default class VTSpan extends React.Component {
   static propTypes = {

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -1,5 +1,7 @@
 import React from "react";
-import { Path, ClipPath, Circle } from "../../index";
+import Path from "./path";
+import ClipPath from "./clip-path";
+import Circle from "./circle";
 import { G } from "react-native-svg";
 import { Voronoi } from "victory-voronoi/es";
 

--- a/lib/components/victory-primitives/whisker.js
+++ b/lib/components/victory-primitives/whisker.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Line } from "../../index";
+import Line from "./line";
 import { G } from "react-native-svg";
 import { Whisker } from "victory-core/es";
 

--- a/lib/components/victory-scatter.js
+++ b/lib/components/victory-scatter.js
@@ -2,10 +2,9 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryScatter } from "victory-scatter/es";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Point } from "../index";
+import Point from "./victory-primitives/point";
 
 export default class extends VictoryScatter {
   static defaultProps = Object.assign({}, VictoryScatter.defaultProps, {

--- a/lib/components/victory-selection-container.js
+++ b/lib/components/victory-selection-container.js
@@ -1,8 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Rect } from "react-native-svg";
-import { SelectionHelpers } from "victory-selection-container/es";
-import { VictoryContainer, NativeHelpers } from "../index";
+import { SelectionHelpers } from "victory-selection-container";
+import VictoryContainer from "./victory-container";
+import NativeHelpers from "../helpers/native-helpers";
 
 // ensure the selection component get native styles
 const DefaultSelectionComponent = ({ style, ...otherProps }) =>

--- a/lib/components/victory-selection-container.js
+++ b/lib/components/victory-selection-container.js
@@ -1,7 +1,10 @@
 import React from "react";
+import { flow } from "lodash";
 import PropTypes from "prop-types";
 import { Rect } from "react-native-svg";
-import { SelectionHelpers } from "victory-selection-container";
+import {
+  VictorySelectionContainer, SelectionHelpers, selectionContainerMixin as originalSelectionMixin
+} from "victory-selection-container";
 import VictoryContainer from "./victory-container";
 import NativeHelpers from "../helpers/native-helpers";
 
@@ -13,17 +16,15 @@ DefaultSelectionComponent.propTypes = {
   style: PropTypes.object
 };
 
-export const selectionContainerMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
-  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
-    selectionStyle: {
-      stroke: "transparent",
-      fill: "black",
-      fillOpacity: 0.1
-    },
+const nativeSelectionMixin = (base) => class VictoryNativeSelectionContainer extends base { // eslint-disable-line max-len
+  // assign native specific defaultProps over web `VictorySelectionContainer` defaultProps
+  static defaultProps = {
+    ...VictorySelectionContainer.defaultProps,
     standalone: true,
     selectionComponent: <DefaultSelectionComponent />
-  });
+  };
 
+  // overrides all web events with native specific events
   static defaultEvents = (props) => {
     return [{
       target: "parent",
@@ -48,7 +49,10 @@ export const selectionContainerMixin = (base) => class VictoryNativeSelectionCon
       }
     }];
   };
-
-  // pass through, so the original container mixin isn't applied twice by combineContainerMixins
-  getChildren({ children }) { return children; }
 };
+
+const combinedMixin = flow(originalSelectionMixin, nativeSelectionMixin);
+
+export const selectionContainerMixin = (base) => combinedMixin(base);
+
+export default selectionContainerMixin(VictoryContainer);

--- a/lib/components/victory-stack.js
+++ b/lib/components/victory-stack.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryStack } from "victory-stack/es";
-
 import VictoryContainer from "./victory-container";
 
 export default class extends VictoryStack {

--- a/lib/components/victory-tooltip.js
+++ b/lib/components/victory-tooltip.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { G } from "react-native-svg";
 import { VictoryTooltip } from "victory-tooltip/es";
-
 import VictoryLabel from "./victory-label";
-import { VictoryPortal, Flyout } from "../index";
+import VictoryPortal from "./victory-portal/victory-portal";
+import Flyout from "./victory-primitives/flyout";
 
 export default class extends VictoryTooltip {
   static defaultProps = Object.assign({}, VictoryTooltip.defaultProps, {

--- a/lib/components/victory-voronoi-container.js
+++ b/lib/components/victory-voronoi-container.js
@@ -1,15 +1,22 @@
 import React from "react";
-import { VoronoiHelpers } from "victory-voronoi-container";
+import { flow } from "lodash";
+import {
+  VictoryVoronoiContainer, VoronoiHelpers, voronoiContainerMixin as originalVoronoiMixin
+} from "victory-voronoi-container";
 import VictoryContainer from "./victory-container";
 import VictoryTooltip from "./victory-tooltip";
 
-export const voronoiContainerMixin = (base) => class VictoryNativeVoronoiContainer extends base {
-  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
-    standalone: true,
+const nativeVoronoiMixin = (base) => class VictoryNativeVoronoiContainer extends base {
+  // assign native specific defaultProps over web `VictoryVoronoiContainer` defaultProps
+  static defaultProps = {
+    ...VictoryVoronoiContainer.defaultProps,
+    activateData: true,
+    activateLabels: true,
     labelComponent: <VictoryTooltip/>,
     voronoiPadding: 5
-  });
+  };
 
+  // overrides all web events with native specific events
   static defaultEvents = (props) => {
     return [{
       target: "parent",
@@ -33,7 +40,11 @@ export const voronoiContainerMixin = (base) => class VictoryNativeVoronoiContain
       }
     }];
   };
-
-  // pass through, so the original container mixin isn't applied twice by combineContainerMixins
-  getChildren({ children }) { return children; }
 };
+
+const combinedMixin = flow(originalVoronoiMixin, nativeVoronoiMixin);
+
+export const voronoiContainerMixin = (base) => combinedMixin(base);
+
+export default voronoiContainerMixin(VictoryContainer);
+

--- a/lib/components/victory-voronoi-container.js
+++ b/lib/components/victory-voronoi-container.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { VoronoiHelpers } from "victory-voronoi-container/es";
-import { VictoryContainer, VictoryTooltip } from "../index";
+import { VoronoiHelpers } from "victory-voronoi-container";
+import VictoryContainer from "./victory-container";
+import VictoryTooltip from "./victory-tooltip";
 
 export const voronoiContainerMixin = (base) => class VictoryNativeVoronoiContainer extends base {
   static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {

--- a/lib/components/victory-voronoi.js
+++ b/lib/components/victory-voronoi.js
@@ -2,10 +2,9 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryVoronoi } from "victory-voronoi/es";
-
 import VictoryLabel from "./victory-label";
 import VictoryContainer from "./victory-container";
-import { Voronoi } from "../index";
+import Voronoi from "./victory-primitives/voronoi";
 
 export default class extends VictoryVoronoi {
   static defaultProps = Object.assign({}, VictoryVoronoi.defaultProps, {

--- a/lib/components/victory-zoom-container.js
+++ b/lib/components/victory-zoom-container.js
@@ -1,16 +1,20 @@
 import React from "react";
+import { flow } from "lodash";
 import VictoryContainer from "./victory-container";
 import VictoryClipContainer from "./victory-clip-container";
+import {
+  VictoryZoomContainer, zoomContainerMixin as originalZoomMixin
+} from "victory-zoom-container";
 import NativeZoomHelpers from "../helpers/native-zoom-helpers";
 
-export const zoomContainerMixin = (base) => class VictoryNativeZoomContainer extends base {
-  static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {
-    clipContainerComponent: <VictoryClipContainer/>,
-    allowZoom: true,
-    allowPan: true,
-    zoomActive: false
-  });
+const nativeZoomMixin = (base) => class VictoryNativeZoomContainer extends base {
+  // assign native specific defaultProps over web `VictoryZoomContainer` defaultProps
+  static defaultProps = {
+    ...VictoryZoomContainer.defaultProps,
+    clipContainerComponent: <VictoryClipContainer/>
+  };
 
+  // overrides all web events with native specific events
   static defaultEvents = (props) => {
     const { disable } = props;
     return [{
@@ -31,7 +35,10 @@ export const zoomContainerMixin = (base) => class VictoryNativeZoomContainer ext
       }
     }];
   };
-
-  // pass through, so the original container mixin isn't applied twice by combineContainerMixins
-  getChildren({ children }) { return children; }
 };
+
+const combinedMixin = flow(originalZoomMixin, nativeZoomMixin);
+
+export const zoomContainerMixin = (base) => combinedMixin(base);
+
+export default zoomContainerMixin(VictoryContainer);

--- a/lib/components/victory-zoom-container.js
+++ b/lib/components/victory-zoom-container.js
@@ -1,5 +1,7 @@
 import React from "react";
-import { VictoryContainer, VictoryClipContainer, NativeZoomHelpers } from "../index";
+import VictoryContainer from "./victory-container";
+import VictoryClipContainer from "./victory-clip-container";
+import NativeZoomHelpers from "../helpers/native-zoom-helpers";
 
 export const zoomContainerMixin = (base) => class VictoryNativeZoomContainer extends base {
   static defaultProps = Object.assign({}, VictoryContainer.defaultProps, {

--- a/lib/helpers/create-container.js
+++ b/lib/helpers/create-container.js
@@ -1,21 +1,21 @@
 import {
   zoomContainerMixin as zoomContainerMixinOriginal
-} from "victory-zoom-container/es";
+} from "victory-zoom-container";
 import {
   voronoiContainerMixin as voronoiContainerMixinOriginal
-} from "victory-voronoi-container/es";
+} from "victory-voronoi-container";
 import {
   selectionContainerMixin as selectionContainerMixinOriginal
-} from "victory-selection-container/es";
+} from "victory-selection-container";
 import {
   brushContainerMixin as brushContainerMixinOriginal
-} from "victory-brush-container/es";
+} from "victory-brush-container";
 import {
   cursorContainerMixin as cursorContainerMixinOriginal
-} from "victory-cursor-container/es";
-import { makeCreateContainerFunction } from "victory-create-container/es";
+} from "victory-cursor-container";
+import { makeCreateContainerFunction } from "victory-create-container";
 
-import { VictoryContainer } from "../index";
+import VictoryContainer from "../components/victory-container";
 
 // load directly, as "../index" would cause a circular dep
 import { zoomContainerMixin } from "../components/victory-zoom-container";

--- a/lib/helpers/create-container.js
+++ b/lib/helpers/create-container.js
@@ -1,23 +1,6 @@
-import {
-  zoomContainerMixin as zoomContainerMixinOriginal
-} from "victory-zoom-container";
-import {
-  voronoiContainerMixin as voronoiContainerMixinOriginal
-} from "victory-voronoi-container";
-import {
-  selectionContainerMixin as selectionContainerMixinOriginal
-} from "victory-selection-container";
-import {
-  brushContainerMixin as brushContainerMixinOriginal
-} from "victory-brush-container";
-import {
-  cursorContainerMixin as cursorContainerMixinOriginal
-} from "victory-cursor-container";
+
 import { makeCreateContainerFunction } from "victory-create-container";
-
 import VictoryContainer from "../components/victory-container";
-
-// load directly, as "../index" would cause a circular dep
 import { zoomContainerMixin } from "../components/victory-zoom-container";
 import { voronoiContainerMixin } from "../components/victory-voronoi-container";
 import { selectionContainerMixin } from "../components/victory-selection-container";
@@ -25,11 +8,11 @@ import { brushContainerMixin } from "../components/victory-brush-container";
 import { cursorContainerMixin } from "../components/victory-cursor-container";
 
 export const createContainer = makeCreateContainerFunction({
-  zoom: [zoomContainerMixinOriginal, zoomContainerMixin],
-  voronoi: [voronoiContainerMixinOriginal, voronoiContainerMixin],
-  selection: [selectionContainerMixinOriginal, selectionContainerMixin],
-  brush: [brushContainerMixinOriginal, brushContainerMixin],
-  cursor: [cursorContainerMixinOriginal, cursorContainerMixin]
+  zoom: [zoomContainerMixin],
+  voronoi: [voronoiContainerMixin],
+  selection: [selectionContainerMixin],
+  brush: [brushContainerMixin],
+  cursor: [cursorContainerMixin]
 }, VictoryContainer);
 
 export default createContainer;

--- a/lib/helpers/native-zoom-helpers.js
+++ b/lib/helpers/native-zoom-helpers.js
@@ -1,8 +1,8 @@
 import { throttle, isFunction, defaults } from "lodash";
 import { Dimensions } from "react-native";
 import isEqual from "react-fast-compare";
-import { Collection } from "victory-core/es";
-import { RawZoomHelpers } from "victory-zoom-container/es";
+import { Collection } from "victory-core";
+import { RawZoomHelpers } from "victory-zoom-container";
 
 const hypotenuse = (x, y) => Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-import createContainer from "./helpers/create-container";
 
 export {
   VictoryAnimation,
@@ -46,22 +45,23 @@ export { default as VictoryVoronoi } from "./components/victory-voronoi";
 export { default as VictoryPie } from "./components/victory-pie";
 export { default as VictoryContainer } from "./components/victory-container";
 export { default as VictoryClipContainer } from "./components/victory-clip-container";
-export { zoomContainerMixin } from "./components/victory-zoom-container";
-export { voronoiContainerMixin } from "./components/victory-voronoi-container";
-export { selectionContainerMixin } from "./components/victory-selection-container";
-export { cursorContainerMixin } from "./components/victory-cursor-container";
-export { brushContainerMixin } from "./components/victory-brush-container";
 export { default as VictoryLabel } from "./components/victory-label";
 export { default as VictoryLegend } from "./components/victory-legend";
 export { default as NativeHelpers } from "./helpers/native-helpers";
 export { default as NativeZoomHelpers } from "./helpers/native-zoom-helpers";
-
-export { createContainer };
-
-// create the containers here
-// so there isn't a circular dependency between victory-*-container and create-container
-export const VictoryZoomContainer = createContainer("zoom");
-export const VictoryBrushContainer = createContainer("brush");
-export const VictorySelectionContainer = createContainer("selection");
-export const VictoryVoronoiContainer = createContainer("voronoi");
-export const VictoryCursorContainer = createContainer("cursor");
+export {
+  zoomContainerMixin, default as VictoryZoomContainer
+} from "./components/victory-zoom-container";
+export {
+  voronoiContainerMixin, default as VictoryVoronoiContainer
+} from "./components/victory-voronoi-container";
+export {
+  selectionContainerMixin, default as VictorySelectionContainer
+} from "./components/victory-selection-container";
+export {
+  cursorContainerMixin, default as VictoryCursorContainer
+} from "./components/victory-cursor-container";
+export {
+  brushContainerMixin, default as VictoryBrushContainer
+} from "./components/victory-brush-container";
+export { createContainer } from "./helpers/create-container";

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ export { default as VictoryClipContainer } from "./components/victory-clip-conta
 export { zoomContainerMixin } from "./components/victory-zoom-container";
 export { voronoiContainerMixin } from "./components/victory-voronoi-container";
 export { selectionContainerMixin } from "./components/victory-selection-container";
+export { cursorContainerMixin } from "./components/victory-cursor-container";
 export { brushContainerMixin } from "./components/victory-brush-container";
 export { default as VictoryLabel } from "./components/victory-label";
 export { default as VictoryLegend } from "./components/victory-legend";


### PR DESCRIPTION
This PR refactors native container mixins to avoid complex import / export situation that resulted from reusing `createContainer` to merge web and native container mixins. Complex imports were causing a an issue when upgrading to babel 7 + `react-native@0.56.0` See https://github.com/FormidableLabs/victory-native/issues/332