### PR TITLE
add option to disable panResponder

### DIFF
--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Svg from "react-native-svg";
 import { assign, get } from "lodash";
 import { View, PanResponder } from "react-native";
@@ -7,10 +8,17 @@ import NativeHelpers from "../helpers/native-helpers";
 import Portal from "./victory-portal/portal";
 
 export default class extends VictoryContainer {
+  static propTypes = assign({}, VictoryContainer.propTypes, {
+    disableResponder: PropTypes.bool,
+    onTouchEnd: PropTypes.func,
+    onTouchStart: PropTypes.func
+  });
+
   constructor(props) {
     super(props);
     this.panResponder = this.getResponder();
   }
+
 
   getResponder() {
     const yes = () => true;
@@ -71,7 +79,9 @@ export default class extends VictoryContainer {
 
   // Overrides method in victory-core
   renderContainer(props, svgProps, style) {
-    const { title, desc, className, width, height, portalZIndex, responsive } = props;
+    const {
+      title, desc, className, width, height, portalZIndex, responsive, disableResponder
+    } = props;
     const children = this.getChildren(props);
     const dimensions = responsive ? { width: "100%", height: "100%" } : { width, height };
     const baseStyle = NativeHelpers.getStyle(style, ["width", "height"]);
@@ -79,8 +89,9 @@ export default class extends VictoryContainer {
     const portalDivStyle = { zIndex: portalZIndex, position: "absolute", top: 0, left: 0 };
     const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
     const portalProps = { width, height, viewBox: svgProps.viewBox, style: portalSvgStyle };
+    const handlers = disableResponder ? {} : this.panResponder.panHandlers;
     return (
-      <View {...this.panResponder.panHandlers} style={divStyle} touchAction="box-none"
+      <View {...handlers} style={divStyle} touchAction="box-none"
         className={className} ref={props.containerRef}
       >
         <Svg {...svgProps} style={dimensions}>

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -9,7 +9,7 @@ import Portal from "./victory-portal/portal";
 
 export default class extends VictoryContainer {
   static propTypes = assign({}, VictoryContainer.propTypes, {
-    disableResponder: PropTypes.bool,
+    disableContainerEvents: PropTypes.bool,
     onTouchEnd: PropTypes.func,
     onTouchStart: PropTypes.func
   });
@@ -80,7 +80,7 @@ export default class extends VictoryContainer {
   // Overrides method in victory-core
   renderContainer(props, svgProps, style) {
     const {
-      title, desc, className, width, height, portalZIndex, responsive, disableResponder
+      title, desc, className, width, height, portalZIndex, responsive, disableContainerEvents
     } = props;
     const children = this.getChildren(props);
     const dimensions = responsive ? { width: "100%", height: "100%" } : { width, height };
@@ -89,7 +89,7 @@ export default class extends VictoryContainer {
     const portalDivStyle = { zIndex: portalZIndex, position: "absolute", top: 0, left: 0 };
     const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
     const portalProps = { width, height, viewBox: svgProps.viewBox, style: portalSvgStyle };
-    const handlers = disableResponder ? {} : this.panResponder.panHandlers;
+    const handlers = disableContainerEvents ? {} : this.panResponder.panHandlers;
     return (
       <View {...handlers} style={divStyle} touchAction="box-none"
         className={className} ref={props.containerRef}


### PR DESCRIPTION
Adds `disableContainerEvents` prop for all containers. This prop will allow users to turn off all panResponder events for any VictoryContainer component. While this prop is `true`,  evented containers like `VictoryVoronoiContainer` to stop registering any events. 

This is will help users who are 
1) trying to use Victory with a different gesture library
2) having issues with press events, especially in android: https://github.com/FormidableLabs/victory-native/issues/96
3) having issues with scrolling: https://github.com/FormidableLabs/victory-native/issues/375

Obviously this solution has some trade offs, since it turns off all container events. I recognize that it isn't a fix for some of the issues I mentioned above, but it should give folks more options.