### PR TITLE
make sure victory-native exports everything victory exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,13 @@
 
 export {
   VictoryAnimation,
-  VictorySharedEvents,
   VictoryTheme,
-  VictoryTransition
+  VictoryTransition,
+  addEvents, Collection, Data, DefaultTransitions, Domain, Events, Helpers, Log,
+  PropTypes, Scale, Style, TextSize, Transitions, Selection, LabelHelpers, Axis, Wrapper
 } from "victory-core/es";
+
+export { VictorySharedEvents } from "victory-shared-events/es";
 
 export { default as Circle } from "./components/victory-primitives/circle";
 export { default as Line } from "./components/victory-primitives/line";


### PR DESCRIPTION
This PR ensures that `victory-native` is exporting all the same components and helpers that `victory` exports.

fixes https://github.com/FormidableLabs/victory-native/issues/388