### PR TITLE
update changelog and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # VictoryNative Changelog
 
-## 30.5.0 (2018-08-24)
+## 30.5.0 (2018-10-19)
 
 - [394](https://github.com/FormidableLabs/victory-native/pull/394) - Correctly clears cursors when `onTouchEnd` is triggered. Thanks @svenlombaert!
 - [393](https://github.com/FormidableLabs/victory-native/pull/393) - Correct reexports for all `victory` components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # VictoryNative Changelog
 
+## 30.5.0 (2018-08-24)
+
+- [394](https://github.com/FormidableLabs/victory-native/pull/394) - Correctly clears cursors when `onTouchEnd` is triggered. Thanks @svenlombaert!
+- [393](https://github.com/FormidableLabs/victory-native/pull/393) - Correct reexports for all `victory` components
+
 ## 30.4.0 (2018-08-24)
 
 -[378](https://github.com/FormidableLabs/victory-native/pull/378) - Adds `disableContainerEvents` prop for all native container components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victory-native",
-  "version": "30.4.0",
+  "version": "30.5.0",
   "description": "Shared libraries and components for Victory",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Version 30.5.0

- [394](https://github.com/FormidableLabs/victory-native/pull/394) - Correctly clears cursors when `onTouchEnd` is triggered. Thanks @svenlombaert!
- [393](https://github.com/FormidableLabs/victory-native/pull/393) - Correct reexports for all `victory` components