### PR TITLE
Exporting native-zoom-helper's Helpers and makeThrottledHandler, to allow extension

### DIFF
--- a/lib/helpers/native-zoom-helpers.js
+++ b/lib/helpers/native-zoom-helpers.js
@@ -100,6 +100,8 @@ const makeThrottledHandler = (handler) => {
   };
 };
 
+export { Helpers, makeThrottledHandler };
+
 export default {
   onTouchStart: Helpers.onMouseDown.bind(Helpers),
   onTouchEnd: Helpers.onTouchEnd.bind(Helpers),


### PR DESCRIPTION
exporting native zoom helper's Helpers and makeThrottledHandler, to allow extending the helpers. resolves #415