### PR TITLE
Fix VictoryContainer pointer events

### DIFF
--- a/demo/src/views/area-view.js
+++ b/demo/src/views/area-view.js
@@ -19,108 +19,90 @@ export default function AreaView() {
 
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryArea />
+      <VictoryArea />
 
+      <VictoryArea
+        polar
+        data={[
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+          { x: 3, y: 3 },
+          { x: 4, y: 1 },
+          { x: 5, y: 3 },
+          { x: 6, y: 4 },
+          { x: 7, y: 2 }
+        ]}
+      />
+
+      <VictoryArea
+        data={[
+          { amount: 1, yield: 1, error: 0.5 },
+          { amount: 2, yield: 2, error: 1.1 },
+          { amount: 3, yield: 3, error: 0 },
+          { amount: 4, yield: 2, error: 0.1 },
+          { amount: 5, yield: 1, error: 1.5 }
+        ]}
+        x={"amount"}
+        y={d => d.yield + d.error}
+      />
+
+      <VictoryArea
+        interpolation="basis"
+        animate={{ duration: 1500 }}
+        data={data}
+      />
+
+      <VictoryGroup width={300} height={375} style={{ data: { opacity: 0.3 } }}>
+        <VictoryArea data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
+        <VictoryArea data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
+        <VictoryArea data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
+      </VictoryGroup>
+
+      <VictoryStack width={300} height={375}>
+        <VictoryArea data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
+        <VictoryArea data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
+        <VictoryArea data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
+      </VictoryStack>
+
+      <VictoryStack
+        width={300}
+        height={450}
+        style={{
+          data: {
+            strokeDasharray: "5,5",
+            strokeWidth: 2,
+            fillOpacity: 0.4
+          }
+        }}
+      >
         <VictoryArea
-          polar
-          data={[
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y: 3 },
-            { x: 4, y: 1 },
-            { x: 5, y: 3 },
-            { x: 6, y: 4 },
-            { x: 7, y: 2 }
-          ]}
-        />
-
-        <VictoryArea
-          data={[
-            { amount: 1, yield: 1, error: 0.5 },
-            { amount: 2, yield: 2, error: 1.1 },
-            { amount: 3, yield: 3, error: 0 },
-            { amount: 4, yield: 2, error: 0.1 },
-            { amount: 5, yield: 1, error: 1.5 }
-          ]}
-          x={"amount"}
-          y={d => d.yield + d.error}
-        />
-
-        <VictoryArea
-          interpolation="basis"
-          animate={{ duration: 1500 }}
-          data={data}
-        />
-
-        <VictoryGroup
-          width={300}
-          height={375}
-          style={{ data: { opacity: 0.3 } }}
-        >
-          <VictoryArea
-            data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]}
-          />
-          <VictoryArea
-            data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]}
-          />
-          <VictoryArea
-            data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]}
-          />
-        </VictoryGroup>
-
-        <VictoryStack width={300} height={375}>
-          <VictoryArea
-            data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]}
-          />
-          <VictoryArea
-            data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]}
-          />
-          <VictoryArea
-            data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]}
-          />
-        </VictoryStack>
-
-        <VictoryStack
-          width={300}
-          height={450}
           style={{
             data: {
-              strokeDasharray: "5,5",
-              strokeWidth: 2,
-              fillOpacity: 0.4
+              fill: "tomato",
+              stroke: "tomato"
             }
           }}
-        >
-          <VictoryArea
-            style={{
-              data: {
-                fill: "tomato",
-                stroke: "tomato"
-              }
-            }}
-            data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]}
-          />
-          <VictoryArea
-            style={{
-              data: {
-                fill: "orange",
-                stroke: "orange"
-              }
-            }}
-            data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]}
-          />
-          <VictoryArea
-            style={{
-              data: {
-                fill: "gold",
-                stroke: "gold"
-              }
-            }}
-            data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]}
-          />
-        </VictoryStack>
-      </View>
+          data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]}
+        />
+        <VictoryArea
+          style={{
+            data: {
+              fill: "orange",
+              stroke: "orange"
+            }
+          }}
+          data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]}
+        />
+        <VictoryArea
+          style={{
+            data: {
+              fill: "gold",
+              stroke: "gold"
+            }
+          }}
+          data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]}
+        />
+      </VictoryStack>
     </ScrollView>
   );
 }

--- a/demo/src/views/axis-view.js
+++ b/demo/src/views/axis-view.js
@@ -7,49 +7,47 @@ import viewStyles from "../styles/view-styles";
 export default function AxisView() {
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryAxis height={100} />
+      <VictoryAxis height={100} />
 
+      <VictoryAxis
+        height={100}
+        scale="time"
+        tickValues={[
+          new Date(1980, 1, 1),
+          new Date(1990, 1, 1),
+          new Date(2000, 1, 1),
+          new Date(2010, 1, 1),
+          new Date(2020, 1, 1)
+        ]}
+        tickFormat={x => x.getFullYear()}
+      />
+
+      <Svg width={320} height={320}>
         <VictoryAxis
-          height={100}
-          scale="time"
-          tickValues={[
-            new Date(1980, 1, 1),
-            new Date(1990, 1, 1),
-            new Date(2000, 1, 1),
-            new Date(2010, 1, 1),
-            new Date(2020, 1, 1)
-          ]}
-          tickFormat={x => x.getFullYear()}
+          width={320}
+          height={320}
+          domain={[-10, 10]}
+          crossAxis
+          offsetY={160}
+          standalone={false}
         />
-
-        <Svg width={320} height={320}>
-          <VictoryAxis
-            width={320}
-            height={320}
-            domain={[-10, 10]}
-            crossAxis
-            offsetY={160}
-            standalone={false}
-          />
-          <VictoryAxis
-            dependentAxis
-            width={320}
-            height={320}
-            domain={[-10, 10]}
-            crossAxis
-            offsetX={160}
-            standalone={false}
-          />
-        </Svg>
-
         <VictoryAxis
           dependentAxis
-          padding={{ left: 50, top: 20, bottom: 20 }}
-          scale="log"
-          domain={[1, 5]}
+          width={320}
+          height={320}
+          domain={[-10, 10]}
+          crossAxis
+          offsetX={160}
+          standalone={false}
         />
-      </View>
+      </Svg>
+
+      <VictoryAxis
+        dependentAxis
+        padding={{ left: 50, top: 20, bottom: 20 }}
+        scale="log"
+        domain={[1, 5]}
+      />
     </ScrollView>
   );
 }

--- a/demo/src/views/bar-view.js
+++ b/demo/src/views/bar-view.js
@@ -6,54 +6,52 @@ import viewStyles from "../styles/view-styles";
 export default function BarView() {
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryBar />
+      <VictoryBar />
 
-        <VictoryBar
-          polar
-          data={[
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y: 3 },
-            { x: 4, y: 2 },
-            { x: 5, y: 1 }
-          ]}
-        />
+      <VictoryBar
+        polar
+        data={[
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+          { x: 3, y: 3 },
+          { x: 4, y: 2 },
+          { x: 5, y: 1 }
+        ]}
+      />
 
-        <VictoryGroup
-          width={300}
-          height={375}
-          offset={20}
-          colorScale={"qualitative"}
-        >
-          <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
-          <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
-          <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
-        </VictoryGroup>
+      <VictoryGroup
+        width={300}
+        height={375}
+        offset={20}
+        colorScale={"qualitative"}
+      >
+        <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
+        <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
+        <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
+      </VictoryGroup>
 
-        <VictoryStack width={300} height={375} colorScale={"qualitative"}>
-          <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
-          <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
-          <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
-        </VictoryStack>
+      <VictoryStack width={300} height={375} colorScale={"qualitative"}>
+        <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]} />
+        <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 1 }]} />
+        <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 2 }]} />
+      </VictoryStack>
 
-        <VictoryBar
-          height={375}
-          padding={75}
-          style={{
-            data: {
-              fill: data => (data.y > 2 ? "red" : "blue")
-            }
-          }}
-          data={[
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y: 3 },
-            { x: 4, y: 2 },
-            { x: 5, y: 1 }
-          ]}
-        />
-      </View>
+      <VictoryBar
+        height={375}
+        padding={75}
+        style={{
+          data: {
+            fill: data => (data.y > 2 ? "red" : "blue")
+          }
+        }}
+        data={[
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+          { x: 3, y: 3 },
+          { x: 4, y: 2 },
+          { x: 5, y: 1 }
+        ]}
+      />
     </ScrollView>
   );
 }

--- a/demo/src/views/boxplot-view.js
+++ b/demo/src/views/boxplot-view.js
@@ -19,36 +19,34 @@ export default function BoxPlotView() {
 
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryChart domainPadding={50}>
-          <VictoryBoxPlot
-            minLabels
-            maxLabels
-            boxWidth={10}
-            data={[
-              { x: "red", y: [5, 10, 9, 2] },
-              { x: "blue", y: [1, 15, 6, 8] },
-              { x: "green", y: [3, 5, 6, 9] },
-              { x: "yellow", y: [5, 20, 8, 12] },
-              { x: "white", y: [2, 11, 12, 13] }
-            ]}
-          />
-        </VictoryChart>
-        <VictoryChart domainPadding={50}>
-          <VictoryBoxPlot
-            labels
-            boxWidth={10}
-            horizontal
-            y="type"
-            data={[
-              { type: 1, min: 1, max: 18, median: 8, q1: 5, q3: 15 },
-              { type: 2, min: 4, max: 20, median: 10, q1: 7, q3: 15 },
-              { type: 3, min: 3, max: 12, median: 6, q1: 5, q3: 10 }
-            ]}
-          />
-        </VictoryChart>
-        <VictoryBoxPlot animate boxWidth={10} data={data} />
-      </View>
+      <VictoryChart domainPadding={50}>
+        <VictoryBoxPlot
+          minLabels
+          maxLabels
+          boxWidth={10}
+          data={[
+            { x: "red", y: [5, 10, 9, 2] },
+            { x: "blue", y: [1, 15, 6, 8] },
+            { x: "green", y: [3, 5, 6, 9] },
+            { x: "yellow", y: [5, 20, 8, 12] },
+            { x: "white", y: [2, 11, 12, 13] }
+          ]}
+        />
+      </VictoryChart>
+      <VictoryChart domainPadding={50}>
+        <VictoryBoxPlot
+          labels
+          boxWidth={10}
+          horizontal
+          y="type"
+          data={[
+            { type: 1, min: 1, max: 18, median: 8, q1: 5, q3: 15 },
+            { type: 2, min: 4, max: 20, median: 10, q1: 7, q3: 15 },
+            { type: 3, min: 3, max: 12, median: 6, q1: 5, q3: 10 }
+          ]}
+        />
+      </VictoryChart>
+      <VictoryBoxPlot animate boxWidth={10} data={data} />
     </ScrollView>
   );
 }

--- a/demo/src/views/chart-view.js
+++ b/demo/src/views/chart-view.js
@@ -42,147 +42,139 @@ export default function ChartView() {
 
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryChart>
-          <VictoryBar />
-          <VictoryLine />
-        </VictoryChart>
+      <VictoryChart>
+        <VictoryBar />
+        <VictoryLine />
+      </VictoryChart>
 
-        <VictoryChart>
-          <VictoryCandlestick data={candleData} />
-        </VictoryChart>
+      <VictoryChart>
+        <VictoryCandlestick data={candleData} />
+      </VictoryChart>
 
-        <VictoryChart domain={{ x: [0, 4] }}>
-          <VictoryGroup
-            labels={["a", "b", "c"]}
-            offset={10}
-            colorScale={"qualitative"}
-          >
-            <VictoryBar
-              data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }]}
-            />
-            <VictoryBar
-              data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }]}
-            />
-            <VictoryBar
-              data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }]}
-            />
-          </VictoryGroup>
-        </VictoryChart>
+      <VictoryChart domain={{ x: [0, 4] }}>
+        <VictoryGroup
+          labels={["a", "b", "c"]}
+          offset={10}
+          colorScale={"qualitative"}
+        >
+          <VictoryBar data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }]} />
+          <VictoryBar data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }]} />
+          <VictoryBar data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }]} />
+        </VictoryGroup>
+      </VictoryChart>
 
-        <VictoryChart>
-          <VictoryScatter
-            labelComponent={<VictoryTooltip />}
-            data={[
-              {
-                x: 1,
-                y: 3,
-                fill: "red",
-                symbol: "plus",
-                size: 6,
-                label: "Red"
-              },
-              {
-                x: 2,
-                y: 5,
-                fill: "magenta",
-                size: 9,
-                opacity: 0.4,
-                label: "Magenta"
-              },
-              {
-                x: 3,
-                y: 4,
+      <VictoryChart>
+        <VictoryScatter
+          labelComponent={<VictoryTooltip />}
+          data={[
+            {
+              x: 1,
+              y: 3,
+              fill: "red",
+              symbol: "plus",
+              size: 6,
+              label: "Red"
+            },
+            {
+              x: 2,
+              y: 5,
+              fill: "magenta",
+              size: 9,
+              opacity: 0.4,
+              label: "Magenta"
+            },
+            {
+              x: 3,
+              y: 4,
+              fill: "orange",
+              size: 5,
+              label: "Orange"
+            },
+            {
+              x: 4,
+              y: 2,
+              fill: "brown",
+              symbol: "square",
+              size: 6,
+              label: "Brown"
+            },
+            {
+              x: 5,
+              y: 5,
+              fill: "black",
+              symbol: "triangleUp",
+              size: 5,
+              label: "Black"
+            }
+          ]}
+        />
+      </VictoryChart>
+      <VictoryChart animate={{ duration: 2000 }}>
+        <VictoryArea data={transitionData} />
+      </VictoryChart>
+      <VictoryChart animate={{ duration: 2000 }}>
+        <VictoryBar
+          labels={() => "Hi"}
+          data={transitionData}
+          style={{
+            data: {
+              fill: "tomato",
+              width: 12
+            }
+          }}
+          animate={{
+            onExit: {
+              duration: 500,
+              before: () => ({
+                y: 0,
                 fill: "orange",
-                size: 5,
-                label: "Orange"
-              },
-              {
-                x: 4,
-                y: 2,
-                fill: "brown",
-                symbol: "square",
-                size: 6,
-                label: "Brown"
-              },
-              {
-                x: 5,
-                y: 5,
-                fill: "black",
-                symbol: "triangleUp",
-                size: 5,
-                label: "Black"
-              }
+                label: "BYE"
+              })
+            }
+          }}
+        />
+      </VictoryChart>
+
+      <VictoryChart>
+        <VictoryStack>
+          <VictoryArea
+            data={[
+              { x: "a", y: 2 },
+              { x: "b", y: 3 },
+              { x: "c", y: 5 },
+              { x: "d", y: 4 },
+              { x: "e", y: 7 }
             ]}
           />
-        </VictoryChart>
-        <VictoryChart animate={{ duration: 2000 }}>
-          <VictoryArea data={transitionData} />
-        </VictoryChart>
-        <VictoryChart animate={{ duration: 2000 }}>
-          <VictoryBar
-            labels={() => "Hi"}
-            data={transitionData}
-            style={{
-              data: {
-                fill: "tomato",
-                width: 12
-              }
-            }}
-            animate={{
-              onExit: {
-                duration: 500,
-                before: () => ({
-                  y: 0,
-                  fill: "orange",
-                  label: "BYE"
-                })
-              }
-            }}
+          <VictoryArea
+            data={[
+              { x: "a", y: 1 },
+              { x: "b", y: 4 },
+              { x: "c", y: 5 },
+              { x: "d", y: 7 },
+              { x: "e", y: 5 }
+            ]}
           />
-        </VictoryChart>
-
-        <VictoryChart>
-          <VictoryStack>
-            <VictoryArea
-              data={[
-                { x: "a", y: 2 },
-                { x: "b", y: 3 },
-                { x: "c", y: 5 },
-                { x: "d", y: 4 },
-                { x: "e", y: 7 }
-              ]}
-            />
-            <VictoryArea
-              data={[
-                { x: "a", y: 1 },
-                { x: "b", y: 4 },
-                { x: "c", y: 5 },
-                { x: "d", y: 7 },
-                { x: "e", y: 5 }
-              ]}
-            />
-            <VictoryArea
-              data={[
-                { x: "a", y: 3 },
-                { x: "b", y: 2 },
-                { x: "c", y: 6 },
-                { x: "d", y: 2 },
-                { x: "e", y: 6 }
-              ]}
-            />
-            <VictoryArea
-              data={[
-                { x: "a", y: 2 },
-                { x: "b", y: 3 },
-                { x: "c", y: 3 },
-                { x: "d", y: 4 },
-                { x: "e", y: 7 }
-              ]}
-            />
-          </VictoryStack>
-        </VictoryChart>
-      </View>
+          <VictoryArea
+            data={[
+              { x: "a", y: 3 },
+              { x: "b", y: 2 },
+              { x: "c", y: 6 },
+              { x: "d", y: 2 },
+              { x: "e", y: 6 }
+            ]}
+          />
+          <VictoryArea
+            data={[
+              { x: "a", y: 2 },
+              { x: "b", y: 3 },
+              { x: "c", y: 3 },
+              { x: "d", y: 4 },
+              { x: "e", y: 7 }
+            ]}
+          />
+        </VictoryStack>
+      </VictoryChart>
     </ScrollView>
   );
 }

--- a/demo/src/views/errors-tooltips-view.js
+++ b/demo/src/views/errors-tooltips-view.js
@@ -18,20 +18,18 @@ export default function ErrorsTooltipsView() {
       <Text style={[viewStyles.header, viewStyles.monospace]}>
         {"<VictoryErrorBar />"}
       </Text>
-      <View pointerEvents="none">
-        <VictoryErrorBar
-          style={{
-            data: { stroke: "red", strokeWidth: 2 }
-          }}
-          data={[
-            { x: 1, y: 1, errorX: [1, 0.5], errorY: 0.1 },
-            { x: 2, y: 2, errorX: [1, 3], errorY: 0.1 },
-            { x: 3, y: 3, errorX: [1, 3], errorY: [0.2, 0.3] },
-            { x: 4, y: 2, errorX: [1, 0.5], errorY: 0.1 },
-            { x: 5, y: 1, errorX: [1, 0.5], errorY: 0.2 }
-          ]}
-        />
-      </View>
+      <VictoryErrorBar
+        style={{
+          data: { stroke: "red", strokeWidth: 2 }
+        }}
+        data={[
+          { x: 1, y: 1, errorX: [1, 0.5], errorY: 0.1 },
+          { x: 2, y: 2, errorX: [1, 3], errorY: 0.1 },
+          { x: 3, y: 3, errorX: [1, 3], errorY: [0.2, 0.3] },
+          { x: 4, y: 2, errorX: [1, 0.5], errorY: 0.1 },
+          { x: 5, y: 1, errorX: [1, 0.5], errorY: 0.2 }
+        ]}
+      />
       <Text style={viewStyles.header}>{"Tooltips"}</Text>
       <VictoryChart>
         <VictoryScatter

--- a/demo/src/views/line-view.js
+++ b/demo/src/views/line-view.js
@@ -21,100 +21,98 @@ export default function LineView() {
 
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryLine />
+      <VictoryLine />
 
-        <VictoryLine
-          polar
-          data={[
-            { x: 0, y: 1 },
-            { x: 1, y: 3 },
-            { x: 2, y: 2 },
-            { x: 3, y: 4 },
-            { x: 4, y: 3 },
-            { x: 5, y: 5 }
-          ]}
-        />
+      <VictoryLine
+        polar
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 3 },
+          { x: 2, y: 2 },
+          { x: 3, y: 4 },
+          { x: 4, y: 3 },
+          { x: 5, y: 5 }
+        ]}
+      />
 
-        <VictoryLine
-          data={[
-            { amount: 1, yield: 1, error: 0.5 },
-            { amount: 2, yield: 2, error: 1.1 },
-            { amount: 3, yield: 3, error: 0 },
-            { amount: 4, yield: 2, error: 0.1 },
-            { amount: 5, yield: 1, error: 1.5 }
-          ]}
-          x={"amount"}
-          y={data => data.yield + data.error}
-        />
+      <VictoryLine
+        data={[
+          { amount: 1, yield: 1, error: 0.5 },
+          { amount: 2, yield: 2, error: 1.1 },
+          { amount: 3, yield: 3, error: 0 },
+          { amount: 4, yield: 2, error: 0.1 },
+          { amount: 5, yield: 1, error: 1.5 }
+        ]}
+        x={"amount"}
+        y={data => data.yield + data.error}
+      />
 
-        <VictoryLine y={data => Math.sin(2 * Math.PI * data.x)} />
+      <VictoryLine y={data => Math.sin(2 * Math.PI * data.x)} />
 
-        <VictoryLine
-          height={300}
-          domain={[0, 5]}
-          padding={75}
-          data={[
-            { x: 0, y: 1 },
-            { x: 1, y: 3 },
-            { x: 2, y: 2 },
-            { x: 3, y: 4 },
-            { x: 4, y: 3 },
-            { x: 5, y: 5 }
-          ]}
-          interpolation="cardinal"
-          labels={() => "LINE"}
-          style={{
-            data: {
-              stroke: "#822722",
-              strokeWidth: 3
-            },
-            labels: { fontSize: 12 }
-          }}
-        />
+      <VictoryLine
+        height={300}
+        domain={[0, 5]}
+        padding={75}
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 3 },
+          { x: 2, y: 2 },
+          { x: 3, y: 4 },
+          { x: 4, y: 3 },
+          { x: 5, y: 5 }
+        ]}
+        interpolation="cardinal"
+        labels={() => "LINE"}
+        style={{
+          data: {
+            stroke: "#822722",
+            strokeWidth: 3
+          },
+          labels: { fontSize: 12 }
+        }}
+      />
 
-        <VictoryLine
-          width={300}
-          style={{
-            data: {
-              stroke: data => {
-                const strokeY = data.map(d => d.y);
-                return Math.max(...strokeY) > 2 ? "red" : "blue";
-              }
+      <VictoryLine
+        width={300}
+        style={{
+          data: {
+            stroke: data => {
+              const strokeY = data.map(d => d.y);
+              return Math.max(...strokeY) > 2 ? "red" : "blue";
             }
-          }}
-          data={[
-            { x: 0, y: 1 },
-            { x: 1, y: 3 },
-            { x: 2, y: 2 },
-            { x: 3, y: 4 },
-            { x: 4, y: 3 },
-            { x: 5, y: 5 }
-          ]}
-        />
+          }
+        }}
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 3 },
+          { x: 2, y: 2 },
+          { x: 3, y: 4 },
+          { x: 4, y: 3 },
+          { x: 5, y: 5 }
+        ]}
+      />
 
-        <VictoryLine
-          style={{
-            data: { stroke: "red", strokeWidth: 9 }
-          }}
-          interpolation={"linear"}
-          data={[
-            { x: 0, y: 1 },
-            { x: 1, y: 3 },
-            { x: 2, y: 2 },
-            { x: 3, y: 4 },
-            { x: 4, y: 3 },
-            { x: 5, y: 5 }
-          ]}
-        />
+      <VictoryLine
+        style={{
+          data: { stroke: "red", strokeWidth: 9 }
+        }}
+        interpolation={"linear"}
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 3 },
+          { x: 2, y: 2 },
+          { x: 3, y: 4 },
+          { x: 4, y: 3 },
+          { x: 5, y: 5 }
+        ]}
+      />
 
-        <VictoryLine
-          style={{ data: styles }}
-          interpolation="basis"
-          animate={{ duration: 1500 }}
-          y={y}
-        />
-      </View>
+      <VictoryLine
+        style={{ data: styles }}
+        interpolation="basis"
+        animate={{ duration: 1500 }}
+        y={y}
+      />
     </ScrollView>
   );
 }

--- a/demo/src/views/pie-view.js
+++ b/demo/src/views/pie-view.js
@@ -19,76 +19,74 @@ export default function PieView() {
 
   return (
     <ScrollView style={viewStyles.container}>
-      <View pointerEvents="none">
-        <VictoryPie
-          innerRadius={75}
-          labelRadius={125}
-          style={{ labels: { fontSize: 20 } }}
-          data={data}
-          animate={{ duration: 1500 }}
-        />
+      <VictoryPie
+        innerRadius={75}
+        labelRadius={125}
+        style={{ labels: { fontSize: 20 } }}
+        data={data}
+        animate={{ duration: 1500 }}
+      />
 
-        <VictoryPie
-          style={{
-            data: {
-              stroke: "none",
-              opacity: 0.3
-            }
-          }}
-        />
-        <VictoryPie innerRadius={90} />
-        <VictoryPie endAngle={90} startAngle={-90} />
-        <VictoryPie
-          endAngle={90}
-          innerRadius={90}
-          padAngle={5}
-          startAngle={-90}
-        />
-        <VictoryPie
-          style={{
-            labels: {
-              fill: "white",
-              stroke: "none",
-              fontSize: 15,
-              fontWeight: "bold"
-            }
-          }}
-          data={[
-            { x: "<5", y: 6279 },
-            { x: "5-13", y: 9182 },
-            { x: "14-17", y: 5511 },
-            { x: "18-24", y: 7164 },
-            { x: "25-44", y: 6716 },
-            { x: "45-64", y: 4263 },
-            { x: "≥65", y: 7502 }
-          ]}
-          innerRadius={70}
-          labelRadius={100}
-          colorScale={[
-            "#D85F49",
-            "#F66D3B",
-            "#D92E1D",
-            "#D73C4C",
-            "#FFAF59",
-            "#E28300",
-            "#F6A57F"
-          ]}
-        />
-        <VictoryPie
-          style={{
-            data: {
-              stroke: d => (d.y > 75 ? "black" : "none"),
-              opacity: d => (d.y > 75 ? 1 : 0.4)
-            }
-          }}
-          data={[
-            { x: "Cat", y: 62 },
-            { x: "Dog", y: 91 },
-            { x: "Fish", y: 55 },
-            { x: "Bird", y: 55 }
-          ]}
-        />
-      </View>
+      <VictoryPie
+        style={{
+          data: {
+            stroke: "none",
+            opacity: 0.3
+          }
+        }}
+      />
+      <VictoryPie innerRadius={90} />
+      <VictoryPie endAngle={90} startAngle={-90} />
+      <VictoryPie
+        endAngle={90}
+        innerRadius={90}
+        padAngle={5}
+        startAngle={-90}
+      />
+      <VictoryPie
+        style={{
+          labels: {
+            fill: "white",
+            stroke: "none",
+            fontSize: 15,
+            fontWeight: "bold"
+          }
+        }}
+        data={[
+          { x: "<5", y: 6279 },
+          { x: "5-13", y: 9182 },
+          { x: "14-17", y: 5511 },
+          { x: "18-24", y: 7164 },
+          { x: "25-44", y: 6716 },
+          { x: "45-64", y: 4263 },
+          { x: "≥65", y: 7502 }
+        ]}
+        innerRadius={70}
+        labelRadius={100}
+        colorScale={[
+          "#D85F49",
+          "#F66D3B",
+          "#D92E1D",
+          "#D73C4C",
+          "#FFAF59",
+          "#E28300",
+          "#F6A57F"
+        ]}
+      />
+      <VictoryPie
+        style={{
+          data: {
+            stroke: d => (d.y > 75 ? "black" : "none"),
+            opacity: d => (d.y > 75 ? 1 : 0.4)
+          }
+        }}
+        data={[
+          { x: "Cat", y: 62 },
+          { x: "Dog", y: 91 },
+          { x: "Fish", y: 55 },
+          { x: "Bird", y: 55 }
+        ]}
+      />
     </ScrollView>
   );
 }

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -19,7 +19,6 @@ export default class extends VictoryContainer {
     this.panResponder = this.getResponder();
   }
 
-
   getResponder() {
     const yes = () => true;
     const no = () => false;
@@ -80,27 +79,52 @@ export default class extends VictoryContainer {
   // Overrides method in victory-core
   renderContainer(props, svgProps, style) {
     const {
-      title, desc, className, width, height, portalZIndex, responsive, disableContainerEvents
+      title,
+      desc,
+      className,
+      width,
+      height,
+      portalZIndex,
+      responsive,
+      disableContainerEvents
     } = props;
     const children = this.getChildren(props);
-    const dimensions = responsive ? { width: "100%", height: "100%" } : { width, height };
+    const dimensions = responsive
+      ? { width: "100%", height: "100%" }
+      : { width, height };
     const baseStyle = NativeHelpers.getStyle(style, ["width", "height"]);
     const divStyle = assign({}, baseStyle, { position: "relative" });
-    const portalDivStyle = { zIndex: portalZIndex, position: "absolute", top: 0, left: 0 };
+    const portalDivStyle = {
+      zIndex: portalZIndex,
+      position: "absolute",
+      top: 0,
+      left: 0
+    };
     const portalSvgStyle = assign({ overflow: "visible" }, dimensions);
-    const portalProps = { width, height, viewBox: svgProps.viewBox, style: portalSvgStyle };
-    const handlers = disableContainerEvents ? {} : this.panResponder.panHandlers;
+    const portalProps = {
+      width,
+      height,
+      viewBox: svgProps.viewBox,
+      style: portalSvgStyle
+    };
+    const handlers = disableContainerEvents
+      ? {}
+      : this.panResponder.panHandlers;
     return (
-      <View {...handlers} style={divStyle} touchAction="box-none"
-        className={className} ref={props.containerRef}
+      <View
+        {...handlers}
+        style={divStyle}
+        pointerEvents="box-none"
+        className={className}
+        ref={props.containerRef}
       >
         <Svg {...svgProps} style={dimensions}>
           {title ? <title id="title">{title}</title> : null}
           {desc ? <desc id="desc">{desc}</desc> : null}
           {children}
         </Svg>
-        <View style={portalDivStyle} touchAction="box-none" pointerEvents="box-none">
-          <Portal {...portalProps} ref={this.savePortalRef}/>
+        <View style={portalDivStyle} pointerEvents="box-none">
+          <Portal {...portalProps} ref={this.savePortalRef} />
         </View>
       </View>
     );


### PR DESCRIPTION
This removes the View wrapper from the demo and fixes the library by ensuring `touchAction` is replaced with `pointerEvents` this allows for natural scrolling when charts are in scroll views.