### PR TITLE
Only block native responder when we need to.

### DIFF
--- a/demo/src/views/area-view.js
+++ b/demo/src/views/area-view.js
@@ -1,6 +1,6 @@
 /*global setInterval clearInterval*/
 import React from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView } from "react-native";
 import { VictoryArea, VictoryGroup, VictoryStack } from "victory-native";
 import viewStyles from "../styles/view-styles";
 import { getData } from "../data";

--- a/demo/src/views/errors-tooltips-view.js
+++ b/demo/src/views/errors-tooltips-view.js
@@ -8,10 +8,10 @@ import {
   VictoryPortal,
   VictoryScatter,
   VictoryTooltip,
-  VictoryErrorBar
+  VictoryErrorBar,
+  VictoryVoronoiContainer
 } from "victory-native";
 import viewStyles from "../styles/view-styles";
-import VictoryVoronoiContainer from "../../../lib/components/victory-voronoi-container";
 
 export default function ErrorsTooltipsView() {
   return (
@@ -35,6 +35,7 @@ export default function ErrorsTooltipsView() {
       <VictoryChart containerComponent={<VictoryVoronoiContainer />}>
         <VictoryScatter
           labelComponent={<VictoryTooltip />}
+          style={{ data: { fill: d => d.fill } }}
           data={[
             {
               x: 1,
@@ -70,13 +71,14 @@ export default function ErrorsTooltipsView() {
             {
               x: 5,
               y: 5,
-              fill: "black",
+              fill: "green",
               symbol: "triangleUp",
               size: 5,
-              label: "Black"
+              label: "Green"
             }
           ]}
-        /></VictoryChart>
+        />
+      </VictoryChart>
       <VictoryChart
         events={[
           {

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -7,6 +7,9 @@ import { VictoryContainer } from "victory-core/es";
 import NativeHelpers from "../helpers/native-helpers";
 import Portal from "./victory-portal/portal";
 
+const yes = () => true;
+const no = () => false;
+
 export default class extends VictoryContainer {
   static propTypes = assign({}, VictoryContainer.propTypes, {
     disableContainerEvents: PropTypes.bool,
@@ -20,8 +23,19 @@ export default class extends VictoryContainer {
   }
 
   getResponder() {
-    const yes = () => true;
-    const no = () => false;
+    let shouldBlockNativeResponder = no;
+    if (
+      this.props &&
+      (this.props.allowDrag ||
+        this.props.allowDraw ||
+        this.props.allowResize ||
+        this.props.allowSelection ||
+        this.props.allowPan ||
+        this.props.allowZoom)
+    ) {
+      shouldBlockNativeResponder = yes;
+    }
+
     return PanResponder.create({
       onStartShouldSetPanResponder: yes,
 
@@ -31,7 +45,7 @@ export default class extends VictoryContainer {
 
       onMoveShouldSetPanResponderCapture: yes,
 
-      onShouldBlockNativeResponder: yes,
+      onShouldBlockNativeResponder: shouldBlockNativeResponder,
 
       onPanResponderTerminationRequest: yes,
       // User has started a touch move


### PR DESCRIPTION
Previously we would block the native responder in every chart case. We want to only do so when specific guestures are required like pinch, pan, scroll, zoom, and draw.

Furthermore fix the demo to actually use the colors we are mentioning.

This makes scrolling a lot more consistent across both platforms and gives the charts a better feel.