### PR TITLE
README: Fix typo in react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Link react-native:
 ```sh
 $ react-native link react-native-svg
 ```
-**`victory-native@^33.0.0` requires `react-native-svg@^9.0.0` and `react-native@~0.6.0`**
+**`victory-native@^33.0.0` requires `react-native-svg@^9.0.0` and `react-native@~0.60.0`**
 
 **Please see [Peer Dependencies and Version Requirements](#peer-dependencies-and-version-requirements) for requirements for previous versions of `victory-native`**
 
@@ -51,7 +51,7 @@ export default App;
 **Note:** `react-native-svg` has strict version requirements for both `react` and `react-native`. Please match versions to those required by `react-native-svg`. See the up-to-date requirements on the [react-native-svg Readme][react-native-svg-readme].
 We encourage you to use the latest version of `react-native-svg` possible for your project, as `victory-native` issues are frequently solved by `react-native-svg` bugfixes.
 
-- `victory-native@^33.0.0` requires `react-native-svg@^9.0.0` and `react-native@~0.6.0`
+- `victory-native@^33.0.0` requires `react-native-svg@^9.0.0` and `react-native@~0.60.0`
 * `victory-native@^30.0.0` requires `react-native-svg@6.1.x`  or `react-native-svg@^6.5.0`and above
 * `victory-native@^0.16.2` requires `react-native-svg@6.1.x` or `react-native-svg@^6.5.0`
 * ~~`victory-native@~0.16.0` requires `react-native-svg@6.0.0`~~ No longer supported


### PR DESCRIPTION
Fixes a small typo in https://github.com/FormidableLabs/victory-native/commit/415b55d477ee24b0b7aa156b1859731f810c3b4a#diff-04c6e90faac2675aa89e2176d2eec7d8